### PR TITLE
WIP - Batches, dispatch, and nesting

### DIFF
--- a/streams/__init__.py
+++ b/streams/__init__.py
@@ -1,2 +1,3 @@
 from .core import *
 from .sources import *
+from .batch import Batch

--- a/streams/batch.py
+++ b/streams/batch.py
@@ -1,0 +1,17 @@
+try:
+    from cytoolz import accumulate
+except ImportError:
+    from toolz import accumulate
+
+class Batch(tuple):
+    def __stream_map__(self, func):
+        return Batch(map(func, self))
+
+    def __stream_reduce__(self, func, accumulator):
+        if isinstance(accumulator, Batch):
+            return Batch(accumulate(func, self, accumulator[-1]))
+        else:
+            return Batch(accumulate(func, self, accumulator))
+
+    def __stream_merge__(self, *others):
+        return Batch(zip(self, *others))

--- a/streams/batch.py
+++ b/streams/batch.py
@@ -3,15 +3,21 @@ try:
 except ImportError:
     from toolz import accumulate
 
+from .core import no_default
+
 class Batch(tuple):
     def __stream_map__(self, func):
         return Batch(map(func, self))
 
     def __stream_reduce__(self, func, accumulator):
-        if isinstance(accumulator, Batch):
-            return Batch(accumulate(func, self, accumulator[-1]))
+        if accumulator is not no_default:
+            seq = accumulate(func, self, accumulator)
         else:
-            return Batch(accumulate(func, self, accumulator))
+            seq = accumulate(func, self)
+        next(seq)  # burn first element, this is the old accumulator
+        seq = Batch(seq)
+        acc = seq[-1] if seq else accumulator
+        return acc, seq
 
     def __stream_merge__(self, *others):
         return Batch(zip(self, *others))

--- a/streams/batch.py
+++ b/streams/batch.py
@@ -3,10 +3,13 @@ try:
 except ImportError:
     from toolz import accumulate
 
+import functools
 from .core import no_default
 
 class Batch(tuple):
-    def __stream_map__(self, func):
+    def __stream_map__(self, func, **kwargs):
+        if kwargs:
+            func = functools.partial(func, **kwargs)
         return Batch(map(func, self))
 
     def __stream_reduce__(self, func, accumulator):

--- a/streams/batch.py
+++ b/streams/batch.py
@@ -12,7 +12,7 @@ class Batch(tuple):
             func = functools.partial(func, **kwargs)
         return Batch(map(func, self))
 
-    def __stream_reduce__(self, func, accumulator):
+    def __stream_accumulate__(self, func, accumulator):
         if accumulator is not no_default:
             seq = accumulate(func, self, accumulator)
         else:

--- a/streams/core.py
+++ b/streams/core.py
@@ -395,8 +395,8 @@ class scan(Stream):
         Stream.__init__(self, child)
 
     def update(self, x, who=None):
-        if hasattr(x, '__stream_reduce__'):
-            self.state, result = x.__stream_reduce__(self.func, self.state)
+        if hasattr(x, '__stream_accumulate__'):
+            self.state, result = x.__stream_accumulate__(self.func, self.state)
         else:
             self.state, result = stream_accumulate(x, self.func, self.state)
 

--- a/streams/core.py
+++ b/streams/core.py
@@ -394,13 +394,17 @@ class scan(Stream):
         Stream.__init__(self, child)
 
     def update(self, x, who=None):
+        if hasattr(x, '__stream_reduce__'):
+            self.state, result = x.__stream_reduce__(self.func, self.state)
+            if result is not no_default:
+                return self.emit(result)
+            else:
+                return []
+
         if self.state is no_default:
             self.state = x
         else:
-            if hasattr(x, '__stream_reduce__'):
-                result = x.__stream_reduce__(self.func, self.state)
-            else:
-                result = self.func(self.state, x)
+            result = self.func(self.state, x)
             self.state = result
             return self.emit(self.state)
 

--- a/streams/dask.py
+++ b/streams/dask.py
@@ -3,15 +3,19 @@ from tornado.locks import Condition
 from tornado.queues import Queue
 from tornado import gen
 
-from .core import Stream
+from .core import Stream, no_default
 
 
 def __stream_map__(self, func):
-    return default_client().submit(func, self)
+    return self.client.submit(func, self)
 
 
 def __stream_reduce__(self, func, accumulator):
-    return default_client().submit(func, accumulator, self)
+    if accumulator is not no_default:
+        result = self.client.submit(func, accumulator, self)
+        return result, result
+    else:
+        return no_default, self
 
 
 Future.__stream_map__ = __stream_map__

--- a/streams/tests/test_batch.py
+++ b/streams/tests/test_batch.py
@@ -1,0 +1,26 @@
+from streams import Stream, Batch
+from operator import add
+
+
+def inc(x):
+    return x + 1
+
+
+def test_map():
+    source = Stream()
+    L = source.partition(3).map(Batch).map(inc).sink_to_list()
+
+    for i in range(10):
+        source.emit(i)
+
+    assert L == [(1, 2, 3), (4, 5, 6), (7, 8, 9)]
+
+
+def test_accumulate():
+    source = Stream()
+    L = source.partition(3).map(Batch).accumulate(add).sink_to_list()
+
+    for i in range(10):
+        source.emit(i)
+
+    assert L == [(1, 2), (3, 4, 6), (7, 8, 9)]

--- a/streams/tests/test_batch.py
+++ b/streams/tests/test_batch.py
@@ -1,5 +1,8 @@
-from streams import Stream, Batch
 from operator import add
+
+import toolz
+
+from streams import Stream, Batch
 
 
 def inc(x):
@@ -18,9 +21,12 @@ def test_map():
 
 def test_accumulate():
     source = Stream()
-    L = source.partition(3).map(Batch).accumulate(add).sink_to_list()
+    L1 = source.partition(3).map(Batch).accumulate(add).sink_to_list()
+    L2 = source.accumulate(add).sink_to_list()
 
-    for i in range(10):
+    for i in range(9):
         source.emit(i)
 
-    assert L == [(1, 2), (3, 4, 6), (7, 8, 9)]
+    assert all(isinstance(x, tuple) for x in L1)
+
+    assert list(toolz.concat(L1))== L2

--- a/streams/tests/test_protocols.py
+++ b/streams/tests/test_protocols.py
@@ -1,6 +1,7 @@
 from operator import add
 
 from streams import Stream
+from streams.core import no_default
 
 
 def inc(x):
@@ -15,7 +16,11 @@ class Foo(object):
         return Foo(func(self.data))
 
     def __stream_reduce__(self, func, accumulator):
-        return Foo(func(accumulator.data, self.data))
+        if accumulator is no_default:
+            return self, no_default
+        else:
+            result = Foo(func(accumulator.data, self.data))
+            return result, result
 
     def __stream_merge__(self, *others):
         return Foo((self.data,) + tuple(o.data for o in others))

--- a/streams/tests/test_protocols.py
+++ b/streams/tests/test_protocols.py
@@ -15,7 +15,7 @@ class Foo(object):
     def __stream_map__(self, func):
         return Foo(func(self.data))
 
-    def __stream_reduce__(self, func, accumulator):
+    def __stream_accumulate__(self, func, accumulator):
         if accumulator is no_default:
             return self, no_default
         else:


### PR DESCRIPTION
OK, this is a work-in-progress PR that shows some ability to nest different kinds of elements in a stream.  This PR does a few things to enable this:

1.  We make a `Batch` type that is a tuple of many elements as a single batch in a stream
2.  We create a singledispatch system to replace the monkeypatching that we used to do on Futures
3.  We do a bit of magic so that the functions we pass down to elements again checks whatever it runs on and possible nests further.

As a result, we can do the following example, which maps a function over remote batches:


```python
In [1]: from dask.distributed import Client

In [2]: client = Client()

In [3]: from streams import Stream, Batch

In [4]: import streams.dask

In [5]: source = Stream()

In [6]: batches = source.partition(3).map(Batch)

In [7]: futures = streams.dask.scatter(batches)

In [8]: L = futures.map(lambda x: x + 1).sink_to_list()

In [9]: for i in range(9):
   ...:     source.emit(i)
   ...:     

In [10]: L
Out[10]: 
[<Future: status: finished, type: Batch, key: _stream_map-06488d54c44f3a3db136e6c34468eb13>,
 <Future: status: finished, type: Batch, key: _stream_map-cad3989e05761099bf5b22db5992eed3>,
 <Future: status: finished, type: Batch, key: _stream_map-ecd902c4b2cd3a96cb3c73694d64cfe6>]

In [11]: client.gather(L)
Out[11]: [(1, 2, 3), (4, 5, 6), (7, 8, 9)]
```

Note that things like accumulate (which will have to be changed) and merge (which will have to be split) don't work yet.  I wanted to get feedback from @ordirules and @danielballan .