### PR TITLE
ENH: Add Stream classes that expect DataFrames.

### DIFF
--- a/streams/dataframe.py
+++ b/streams/dataframe.py
@@ -1,0 +1,44 @@
+import pandas as pd
+from .core import Stream
+
+
+class sum(Stream):
+    def __init__(self, child):
+        self.cumsum = pd.Series()
+        Stream.__init__(self, child)
+
+    def update(self, x, who=None):
+        self.cumsum = self.cumsum.add(x.sum(), fill_value=0)
+        self.emit(self.cumsum)
+
+
+class mean(Stream):
+    def __init__(self, child):
+        self.cumsum = pd.Series()
+        self.cumcount = pd.Series()
+        Stream.__init__(self, child)
+
+    def update(self, x, who=None):
+        self.cumsum = self.cumsum.add(x.sum(), fill_value=0)
+        self.cumcount = self.cumcount.add(x.count(), fill_value=0)
+        self.emit(self.cumsum / self.cumcount)
+
+
+class min(Stream):
+    def __init__(self, child):
+        self.min = pd.DataFrame()
+        Stream.__init__(self, child)
+
+    def update(self, x, who=None):
+        self.min = pd.concat([self.min, x.min()], 1).T.min()
+        self.emit(self.min)
+
+
+class max(Stream):
+    def __init__(self, child):
+        self.max = pd.DataFrame()
+        Stream.__init__(self, child)
+
+    def update(self, x, who=None):
+        self.max = pd.concat([self.max, x.max()], 1).T.max()
+        self.emit(self.max)

--- a/streams/tests/test_dataframe.py
+++ b/streams/tests/test_dataframe.py
@@ -1,0 +1,46 @@
+from pandas import DataFrame, Series
+from pandas.util.testing import assert_series_equal
+from ..core import Stream
+from .. import dataframe
+
+
+def test_sum():
+    source = Stream()
+    L = dataframe.sum(source).sink_to_list()
+
+    source.emit(DataFrame({'a': [1, 2], 'b': [10, 20]}))
+    assert_series_equal(L[-1], Series([3., 30.], list('ab')))
+
+    source.emit(DataFrame({'a': [3], 'c': [1]}))
+    assert_series_equal(L[-1], Series([6., 30., 1.], list('abc')))
+
+
+def test_mean():
+    source = Stream()
+    L = dataframe.mean(source).sink_to_list()
+
+    source.emit(DataFrame({'a': [1, 2], 'b': [10, 20]}))
+    assert_series_equal(L[-1], Series([1.5, 15.], list('ab')))
+
+    # This tests that 'b' does not change if a DataFrame with no values is
+    # included, while 'a' is updated and 'c' is added.
+    source.emit(DataFrame({'a': [3], 'c': [1]}))
+    assert_series_equal(L[-1], Series([2., 15., 1.], list('abc')))
+
+
+def test_min_and_max():
+    source = Stream()
+    Lmin = dataframe.min(source).sink_to_list()
+    Lmax = dataframe.max(source).sink_to_list()
+
+    source.emit(DataFrame({'a': [1, 2], 'b': [10, 20]}))
+    assert_series_equal(Lmin[-1], Series([1, 10], list('ab')))
+    assert_series_equal(Lmax[-1], Series([2, 20], list('ab')))
+
+    source.emit(DataFrame({'a': [3], 'c': [1]}))
+    assert_series_equal(Lmin[-1], Series([1., 10., 1.], list('abc')))
+    assert_series_equal(Lmax[-1], Series([3., 20., 1.], list('abc')))
+
+    source.emit(DataFrame({'a': [0], 'c': [1]}))
+    assert_series_equal(Lmin[-1], Series([0., 10., 1.], list('abc')))
+    assert_series_equal(Lmax[-1], Series([3., 20., 1.], list('abc')))


### PR DESCRIPTION
This is a modest start at integrating DataFrames with streams, as suggested in the blog post. Example:

```python
In [54]: source = Stream()

In [55]: df = pd.DataFrame({'a': [1,2,3], 'b': [2,3,4]})

In [56]: import streams.dataframe as sd

In [57]: sd.max(source).map(print)
Out[57]: <streams.core.map at 0x111f20940>

In [58]: source.emit(df)
a    3.0
b    4.0
dtype: float64
Out[58]: []

In [59]: source.emit(df)
a    3.0
b    4.0
dtype: float64
Out[59]: []

In [60]: source.emit(df * 2)
a    6.0
b    8.0
dtype: float64
Out[60]: []
```