### PR TITLE
Connect streams

### DIFF
--- a/streamz/core.py
+++ b/streamz/core.py
@@ -108,13 +108,15 @@ class Stream(object):
         self.emit(x)
 
     def connect(self, parent):
-        ''' Connect another child to stream.
-            Note that parents go downstream and children go upstream.
+        ''' Connect this stream to a downstream element.
+
+            Parameters
+            ----------
+            parent: Stream
+                the parent stream (downstream element) to connect to
         '''
-        if self.parents == [None]:
-            self.parents = [parent]
-        else:
-            self.parents.append(parent)
+        # Note : parents go downstream and children go upstream.
+        self.parents.append(parent)
 
         if parent.children == [None]:
             parent.children = [self]

--- a/streamz/core.py
+++ b/streamz/core.py
@@ -104,6 +104,9 @@ class Stream(object):
                 result.append(r)
         return [element for element in result if element is not None]
 
+    def update(self, x, who=None):
+        self.emit(x)
+
     @property
     def child(self):
         if len(self.children) != 1:

--- a/streamz/core.py
+++ b/streamz/core.py
@@ -107,6 +107,20 @@ class Stream(object):
     def update(self, x, who=None):
         self.emit(x)
 
+    def connect(self, parent):
+        ''' Connect another child to stream.
+            Note that parents go downstream and children go upstream.
+        '''
+        if self.parents == [None]:
+            self.parents = [parent]
+        else:
+            self.parents.append(parent)
+
+        if parent.children == [None]:
+            parent.children = [self]
+        else:
+            parent.children.append(self)
+
     @property
     def child(self):
         if len(self.children) != 1:

--- a/streamz/tests/test_core.py
+++ b/streamz/tests/test_core.py
@@ -567,15 +567,21 @@ def test_piping():
 
 
 def test_connect():
-    source = Stream()
-    source2 = Stream()
+    source_downstream = Stream()
+    # connect assumes this default behaviour
+    # of stream initialization
+    assert source_downstream.parents == []
+    assert source_downstream.children == [None]
 
-    sout = source.map(lambda x : x + 1)
+    # initialize the second stream to connect to
+    source_upstream = Stream()
+
+    sout = source_downstream.map(lambda x : x + 1)
     L = list()
     sout = sout.map(L.append)
-    source2.connect(source)
+    source_upstream.connect(source_downstream)
 
-    source2.emit(2)
-    source2.emit(4)
+    source_upstream.emit(2)
+    source_upstream.emit(4)
 
     assert L == [3, 5]

--- a/streamz/tests/test_core.py
+++ b/streamz/tests/test_core.py
@@ -551,21 +551,6 @@ def test_triple_zip_latest():
     assert L_simple == [(1, 'III', 'a'), (2, 'III', 'a'), (3, 'III', 'b')]
 
 
-def test_piping():
-    source = Stream()
-    source2 = Stream()
-    # put source2 upstream of source
-    source2.parents = [source]
-
-    L = list()
-    source.map(L.append)
-
-    source2.emit(1)
-    source2.emit(3)
-
-    assert L == [1,3]
-
-
 def test_connect():
     source_downstream = Stream()
     # connect assumes this default behaviour

--- a/streamz/tests/test_core.py
+++ b/streamz/tests/test_core.py
@@ -549,3 +549,19 @@ def test_triple_zip_latest():
     s3.emit('b')
     s1.emit(3)
     assert L_simple == [(1, 'III', 'a'), (2, 'III', 'a'), (3, 'III', 'b')]
+
+
+def test_piping():
+    source = Stream()
+    source2 = Stream()
+    # put source2 upstream of source
+    #source.children = [source2]
+    source2.parents = [source]
+
+    L = list()
+    source.map(L.append)
+
+    source2.emit(1)
+    source2.emit(3)
+
+    assert L == [1,3]

--- a/streamz/tests/test_core.py
+++ b/streamz/tests/test_core.py
@@ -555,7 +555,6 @@ def test_piping():
     source = Stream()
     source2 = Stream()
     # put source2 upstream of source
-    #source.children = [source2]
     source2.parents = [source]
 
     L = list()

--- a/streamz/tests/test_core.py
+++ b/streamz/tests/test_core.py
@@ -565,3 +565,18 @@ def test_piping():
     source2.emit(3)
 
     assert L == [1,3]
+
+
+def test_connect():
+    source = Stream()
+    source2 = Stream()
+
+    sout = source.map(lambda x : x + 1)
+    L = list()
+    sout = sout.map(L.append)
+    source2.connect(source)
+
+    source2.emit(2)
+    source2.emit(4)
+
+    assert L == [3, 5]


### PR DESCRIPTION
Suggested resolution to #44 . It makes a big difference when visualizing graphs and I'm using it now, so I thought I'd already go ahead and send it. Please let me know if there are better ways.

From issue, changing from `s2.map(s1.emit)` to `s2.connect(s1)` leads to difference of the two figures:

`s2.map(s1.emit)` : http://imgur.com/a/0Z0JA

`s2.connect(s1)` : http://imgur.com/a/rcrX0