### PR TITLE
MTN: name -> stream_name

### DIFF
--- a/examples/plot_graph.py
+++ b/examples/plot_graph.py
@@ -1,9 +1,9 @@
 from streamz import Stream
 from operator import add
 
-source1 = Stream(name='source1')
-source2 = Stream(name='source2')
-source3 = Stream(name='awesome source')
+source1 = Stream(stream_name='source1')
+source2 = Stream(stream_name='source2')
+source3 = Stream(stream_name='awesome source')
 
 n1 = source1.zip(source2)
 n2 = n1.map(add)

--- a/streamz/core.py
+++ b/streamz/core.py
@@ -62,13 +62,12 @@ class Stream(object):
         for child in self.children:
             if child:
                 child.parents.append(self)
-        self.stream_name = stream_name
+        self.name = stream_name
 
     def __str__(self):
         s_list = []
-        if self.stream_name:
-            s_list.append('{}; {}'.format(self.stream_name,
-                                          self.__class__.__name__))
+        if self.name:
+            s_list.append('{}; {}'.format(self.name, self.__class__.__name__))
         else:
             s_list.append(self.__class__.__name__)
 

--- a/streamz/core.py
+++ b/streamz/core.py
@@ -51,7 +51,7 @@ class Stream(object):
     """
     str_list = ['func', 'predicate', 'n', 'interval']
 
-    def __init__(self, child=None, children=None, name=None, **kwargs):
+    def __init__(self, child=None, children=None, stream_name=None, **kwargs):
         self.parents = []
         if children is not None:
             self.children = children
@@ -62,12 +62,13 @@ class Stream(object):
         for child in self.children:
             if child:
                 child.parents.append(self)
-        self.name = name
+        self.stream_name = stream_name
 
     def __str__(self):
         s_list = []
-        if self.name:
-            s_list.append('{}; {}'.format(self.name, self.__class__.__name__))
+        if self.stream_name:
+            s_list.append('{}; {}'.format(self.stream_name,
+                                          self.__class__.__name__))
         else:
             s_list.append(self.__class__.__name__)
 

--- a/streamz/tests/test_core.py
+++ b/streamz/tests/test_core.py
@@ -492,5 +492,5 @@ def test_partition_str():
 
 
 def test_stream_name_str():
-    source = Stream(name='this is not a stream')
+    source = Stream(stream_name='this is not a stream')
     assert str(source) == '<this is not a stream; Stream>'

--- a/streamz/tests/test_graph.py
+++ b/streamz/tests/test_graph.py
@@ -9,8 +9,8 @@ from streamz.utils_test import tmpfile
 
 
 def test_create_graph():
-    source1 = Stream(name='source1')
-    source2 = Stream(name='source2')
+    source1 = Stream(stream_name='source1')
+    source2 = Stream(stream_name='source2')
 
     n1 = source1.zip(source2)
     n2 = n1.map(add)
@@ -23,8 +23,8 @@ def test_create_graph():
 
 
 def test_create_file():
-    source1 = Stream(name='source1')
-    source2 = Stream(name='source2')
+    source1 = Stream(stream_name='source1')
+    source2 = Stream(stream_name='source2')
 
     n1 = source1.zip(source2)
     n2 = n1.map(add)


### PR DESCRIPTION
`name` is a fairly common name, so rename to `stream_name` so no conflicts with map