### PR TITLE
Stream name

### DIFF
--- a/streamz/core.py
+++ b/streamz/core.py
@@ -68,7 +68,7 @@ class Stream(object):
             self.children = children
         else:
             self.children = [child]
-        if self.loop is not None:
+        if loop is not None:
             self._loop = loop
         for child in self.children:
             if child:

--- a/streamz/core.py
+++ b/streamz/core.py
@@ -86,10 +86,8 @@ class Stream(object):
     def __str__(self):
         s_list = []
         if self.name:
-            #print("Printing name {}".format(self.name))
             s_list.append('{}; {}'.format(self.name, self.__class__.__name__))
         else:
-            #print("Nor pringint name {}".format(self.name))
             s_list.append(self.__class__.__name__)
 
         for m in self.str_list:

--- a/streamz/core.py
+++ b/streamz/core.py
@@ -62,14 +62,14 @@ class Stream(object):
 
     str_list = ['func', 'predicate', 'n', 'interval']
 
-    def __init__(self, child=None, children=None, stream_name=None, **kwargs):
+    def __init__(self, child=None, children=None, stream_name=None, loop=None):
         self.parents = weakref.WeakSet()
         if children is not None:
             self.children = children
         else:
             self.children = [child]
-        if kwargs.get('loop'):
-            self._loop = kwargs.get('loop')
+        if self.loop is not None:
+            self._loop = loop
         for child in self.children:
             if child:
                 child.parents.add(self)

--- a/streamz/core.py
+++ b/streamz/core.py
@@ -382,7 +382,6 @@ class filter(Stream):
         # this is one of a few stream specific kwargs
         stream_name = kwargs.pop('stream_name', None)
 
-        Stream.__init__(self, child)
         Stream.__init__(self, child, stream_name=stream_name)
 
     def update(self, x, who=None):

--- a/streamz/core.py
+++ b/streamz/core.py
@@ -211,7 +211,7 @@ class Stream(object):
     def concat(self):
         return self.flatten
 
-    def sink_to_list(self, **kwargs):
+    def sink_to_list(self):
         """ Append all elements of a stream to a list as they come in
 
         Examples
@@ -638,6 +638,7 @@ class zip(Stream):
     _graphviz_shape = 'triangle'
 
     def __init__(self, *children, **kwargs):
+        stream_name = kwargs.pop('stream_name', None)
         self.maxsize = kwargs.pop('maxsize', 10)
         self.buffers = [deque() for _ in children]
         self.condition = Condition()
@@ -651,9 +652,8 @@ class zip(Stream):
 
         children2 = [child for child in children if isinstance(child, Stream)]
 
-        # this is one of a few stream specific kwargs
-        stream_name = kwargs.pop('stream_name', None)
-        Stream.__init__(self, children=children2, stream_name=stream_name)
+        Stream.__init__(self, children=children2, stream_name=stream_name,
+                        **kwargs)
 
     def pack_literals(self):
         """ Fill buffers for literals whenver we empty them """

--- a/streamz/tests/test_core.py
+++ b/streamz/tests/test_core.py
@@ -770,3 +770,37 @@ def test_destroy():
     assert not s.children
     source.emit(2)
     assert L == [2]
+
+def test_stream_name():
+    ''' Test that stream_name is passed correctly to the core methods.'''
+    test_name = "some test name"
+    sin = Stream(stream_name=test_name)
+    sin2 = Stream()
+
+    # add new core methods here, initialized
+    streams = [
+               sin.map(lambda x : x, stream_name=test_name),
+               sin.accumulate(lambda x1, x2 : x1, stream_name=test_name),
+               sin.filter(lambda x : True, stream_name=test_name),
+               sin.partition(2, stream_name=test_name),
+               sin.sliding_window(2, stream_name=test_name),
+               sin.timed_window(.01, stream_name=test_name),
+               sin.rate_limit(.01, stream_name=test_name),
+               sin.delay(.02, stream_name=test_name),
+               sin.buffer(2, stream_name=test_name),
+               sin.zip(sin2, stream_name=test_name),
+               sin.combine_latest(sin2, stream_name=test_name),
+               sin.frequencies(stream_name=test_name),
+               sin.flatten(stream_name=test_name),
+               sin.unique(stream_name=test_name),
+               sin.union(stream_name=test_name),
+               sin.pluck(0, stream_name=test_name),
+               sin.collect(stream_name=test_name),
+               ]
+
+    for s in streams:
+        assert s.name == test_name
+
+    assert sin.name == test_name
+    # when not defined, should be None
+    assert sin2.name is None


### PR DESCRIPTION
we're not passing the names properly. this is just a placeholder. Probably we should define a list of stream only strings and pass these through. One issue is anyone subclassing `__init__` has to be aware of this.
If someone has a better idea let me know. I can look into this later.
This is will affect #59 .

ex:
```python
s = Stream()
s2 = s.map(lambda x : x + 1, stream_name="Foo")
# etc...
```