### PR TITLE
Garbage collect streams

### DIFF
--- a/streamz/sources.py
+++ b/streamz/sources.py
@@ -1,13 +1,14 @@
 from .core import Stream, Sink
-from tornado import gen
 import tornado.ioloop
 
 
 def PeriodicCallback(callback, callback_time, **kwargs):
     source = Stream()
+
     def _():
         result = callback()
         source.emit(result)
+
     pc = tornado.ioloop.PeriodicCallback(_, callback_time, **kwargs)
     pc.start()
     return source

--- a/streamz/tests/test_core.py
+++ b/streamz/tests/test_core.py
@@ -216,7 +216,7 @@ def test_sink_to_file():
 @gen_test()
 def test_counter():
     counter = itertools.count()
-    source = PeriodicCallback(counter.__next__, 0.001)
+    source = PeriodicCallback(lambda: next(counter), 0.001)
     L = source.sink_to_list()
     yield gen.sleep(0.05)
 

--- a/streamz/tests/test_core.py
+++ b/streamz/tests/test_core.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 import itertools
 import operator
 from operator import add
-from time import time
+from time import time, sleep
 
 import pytest
 
@@ -604,7 +604,7 @@ def test_connect():
     source_downstream = Stream()
     # connect assumes this default behaviour
     # of stream initialization
-    assert source_downstream.parents == []
+    assert not(source_downstream.parents)
     assert source_downstream.children == [None]
 
     # initialize the second stream to connect to
@@ -636,3 +636,23 @@ def test_disconnect():
     source.disconnect(upstream)
     source.emit(4)
     assert L == [2, 3]
+
+
+def test_gc():
+    source = Stream()
+
+    L = []
+    a = source.map(L.append)
+
+    source.emit(1)
+    assert L == [1]
+
+    del a
+    import gc; gc.collect()
+    start = time()
+    while source.parents:
+        sleep(0.01)
+        assert time() < start + 1
+
+    source.emit(2)
+    assert L == [1]


### PR DESCRIPTION
We replace parents with a weakref.WeakSet so that streams only stick
around if there is an active reference to them.

The sink method is more durable though.  Sinks place themselves into a
global set so that their common use for side effects remains valid.

Fixes #71