### PR TITLE
Add streaming collections

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
   - conda update conda
 
   # Install dependencies
-  - conda create -n test-streamz python=$TRAVIS_PYTHON_VERSION pytest tornado toolz flake8 coverage codecov networkx graphviz python-graphviz dask distributed -c conda-forge
+  - conda create -n test-streamz python=$TRAVIS_PYTHON_VERSION pytest tornado toolz flake8 coverage codecov networkx graphviz python-graphviz dask distributed pandas -c conda-forge
   - source activate test-streamz
   - pip install git+https://github.com/dask/distributed.git --upgrade --no-deps
 

--- a/streamz/collection.py
+++ b/streamz/collection.py
@@ -6,6 +6,22 @@ _subtypes = []
 
 
 class Streaming(object):
+    """
+    Superclass for streaming collections
+
+    Do not create this class directly, use one of the subclasses instead.
+
+    Parameters
+    ----------
+    stream: streamz.Stream
+    example: object
+        An object to represent an example element of this stream
+
+    See also
+    --------
+    streamz.dataframe.StreamingDataFrame
+    streamz.dataframe.StreamingSequence
+    """
     _subtype = object
 
     def __init__(self, stream=None, example=None):
@@ -15,6 +31,15 @@ class Streaming(object):
         self.stream = stream or Stream()
 
     def map_partitions(self, func, *args, **kwargs):
+        """ Map a function across all batch elements of this stream
+
+        The output stream type will be determined by the action of that
+        function on the example
+
+        See Also
+        --------
+        Streaming.accumulate_partitions
+        """
         example = kwargs.pop('example', None)
         if example is None:
             example = func(self.example, *args, **kwargs)
@@ -26,6 +51,12 @@ class Streaming(object):
         return Streaming(stream, example)
 
     def accumulate_partitions(self, func, *args, **kwargs):
+        """ Accumulate a function with state across batch elements
+
+        See Also
+        --------
+        Streaming.map_partitions
+        """
         start = kwargs.pop('start', core.no_default)
         returns_state = kwargs.pop('returns_state', False)
         example = kwargs.pop('example', None)
@@ -78,6 +109,7 @@ class Streaming(object):
         self.stream.emit(x)
 
     def verify(self, x):
+        """ Verify elements that pass through this stream """
         if not isinstance(x, self._subtype):
             raise TypeError("Expected type %s, got type %s" %
                             (self._subtype, type(x)))

--- a/streamz/collection.py
+++ b/streamz/collection.py
@@ -1,0 +1,83 @@
+import operator
+
+from streamz import Stream, core
+
+_subtypes = []
+
+
+class Streaming(object):
+    _subtype = object
+
+    def __init__(self, stream=None, example=None):
+        assert example is not None
+        self.example = example
+        assert isinstance(self.example, self._subtype)
+        self.stream = stream or Stream()
+
+    def map_partitions(self, func, *args, **kwargs):
+        example = kwargs.pop('example', None)
+        if example is None:
+            example = func(self.example, *args, **kwargs)
+        stream = self.stream.map(func, *args, **kwargs)
+
+        for typ, stream_type in _subtypes:
+            if isinstance(example, typ):
+                return stream_type(stream, example)
+        return Streaming(stream, example)
+
+    def accumulate_partitions(self, func, *args, **kwargs):
+        start = kwargs.pop('start', core.no_default)
+        returns_state = kwargs.pop('returns_state', False)
+        example = kwargs.pop('example', None)
+        if example is None:
+            example = func(start, self.example, *args, **kwargs)
+        if returns_state:
+            _, example = example
+        stream = self.stream.accumulate(func, *args, start=start,
+                returns_state=returns_state, **kwargs)
+
+        for typ, stream_type in _subtypes:
+            if isinstance(example, typ):
+                return stream_type(stream, example)
+        return Streaming(stream, example)
+
+    def __repr__(self):
+        example = self.example
+        if hasattr(example, 'head'):
+            example = example.head(2)
+        return "%s - elements like:\n%r" % (type(self).__name__, example)
+
+    def _repr_html_(self):
+        example = self.example
+        if hasattr(example, 'head'):
+            example = example.head(2)
+        try:
+            body = example._repr_html_()
+        except AttributeError:
+            body = repr(example)
+
+        return "<h5>%s - elements like<h5>\n%s" % (type(self).__name__, body)
+
+    def __add__(self, other):
+        return self.map_partitions(operator.add, other)
+
+    def __mul__(self, other):
+        return self.map_partitions(operator.mul, other)
+
+    def __mod__(self, other):
+        return self.map_partitions(operator.mod, other)
+
+    def __truediv__(self, other):
+        return self.map_partitions(operator.truediv, other)
+
+    def __floordiv__(self, other):
+        return self.map_partitions(operator.floordiv, other)
+
+    def emit(self, x):
+        self.verify(x)
+        self.stream.emit(x)
+
+    def verify(self, x):
+        if not isinstance(x, self._subtype):
+            raise TypeError("Expected type %s, got type %s" %
+                            (self._subtype, type(x)))

--- a/streamz/core.py
+++ b/streamz/core.py
@@ -481,8 +481,13 @@ class Stream(object):
         from .graph import visualize
         return visualize(self, filename, **kwargs)
 
+    def to_dataframe(self, example):
+        """ Convert a stream of Pandas dataframes to a StreamingDataFrame """
+        from .dataframe import StreamingDataFrame
+        return StreamingDataFrame(stream=self, example=example)
+
     def to_sequence(self, **kwargs):
-        """ Convert to a stream of batches """
+        """ Convert to a stream of lists to a StreamingSequence """
         from .sequence import StreamingSequence
         return StreamingSequence(stream=self, **kwargs)
 

--- a/streamz/core.py
+++ b/streamz/core.py
@@ -481,6 +481,42 @@ class Stream(object):
         from .graph import visualize
         return visualize(self, filename, **kwargs)
 
+    @gen.coroutine
+    def from_textfile(self, f, poll_interval=None):
+        """ Read data from file into stream
+
+        Parameters
+        ----------
+        f: file or string
+            File object or filename to read
+        poll_interval: number
+            Number of seconds between which to poll the file
+            If None then don't poll, and instead return without waiting
+
+        Example
+        -------
+        >>> source = Stream()
+        >>> source.map(json.loads).pluck('value').sum()
+        >>> source.from_textfile('myfile.json')
+
+        Returns
+        -------
+        Nothing.  This has the side effect of emitting data into the stream.
+        """
+        if isinstance(f, str):
+            f = open(f)
+
+        while True:
+            line = f.readline()
+            if line:
+                last = self.emit(line)  # TODO: we should yield on emit
+            else:
+                if poll_interval:
+                    yield gen.sleep(poll_interval)
+                    yield last
+                else:
+                    return
+
 
 class Sink(Stream):
     def __init__(self, func, child):

--- a/streamz/core.py
+++ b/streamz/core.py
@@ -481,6 +481,11 @@ class Stream(object):
         from .graph import visualize
         return visualize(self, filename, **kwargs)
 
+    def to_sequence(self, **kwargs):
+        """ Convert to a stream of batches """
+        from .sequence import StreamingSequence
+        return StreamingSequence(stream=self, **kwargs)
+
     @gen.coroutine
     def from_textfile(self, f, poll_interval=None):
         """ Read data from file into stream

--- a/streamz/dataframe.py
+++ b/streamz/dataframe.py
@@ -1,7 +1,7 @@
 from functools import partial
 import operator
 
-from dask.utils import M
+from .utils import M
 import pandas as pd
 
 from .collection import Streaming, _subtypes

--- a/streamz/dataframe.py
+++ b/streamz/dataframe.py
@@ -6,89 +6,15 @@ from streamz import Stream
 from dask.utils import M
 import pandas as pd
 
+from .collection import Streaming, _subtypes
 
-class Streaming(object):
-    _subtype = object
 
-    def __init__(self, stream=None, example=None, columns=None):
-        if columns is not None and example is None:
-            example = pd.DataFrame({c: [] for c in columns})
-        assert example is not None
-        self.example = example
-        assert isinstance(self.example, self._subtype)
-        self.stream = stream or Stream()
+class StreamingFrame(Streaming):
+    def sum(self):
+        return self.accumulate_partitions(_accumulate_sum, start=0)
 
-    def map_partitions(self, func, *args, **kwargs):
-        example = kwargs.pop('example', None)
-        if example is None:
-            example = func(self.example, *args, **kwargs)
-        stream = self.stream.map(func, *args, **kwargs)
-
-        if isinstance(example, pd.DataFrame):
-            return StreamingDataFrame(stream, example)
-        elif isinstance(example, pd.Series):
-            return StreamingSeries(stream, example)
-        else:
-            return Streaming(stream, example)
-
-    def accumulate_partitions(self, func, *args, **kwargs):
-        start = kwargs.pop('start', streamz.core.no_default)
-        returns_state = kwargs.pop('returns_state', False)
-        example = kwargs.pop('example', None)
-        if example is None:
-            example = func(start, self.example, *args, **kwargs)
-        if returns_state:
-            _, example = example
-        stream = self.stream.accumulate(func, *args, start=start,
-                returns_state=returns_state, **kwargs)
-
-        if isinstance(example, pd.DataFrame):
-            return StreamingDataFrame(stream, example)
-        elif isinstance(example, pd.Series):
-            return StreamingSeries(stream, example)
-        else:
-            return Streaming(stream, example)
-
-    def __repr__(self):
-        example = self.example
-        if hasattr(example, 'head'):
-            example = example.head(2)
-        return "%s - elements like:\n%r" % (type(self).__name__, example)
-
-    def _repr_html_(self):
-        example = self.example
-        if hasattr(example, 'head'):
-            example = example.head(2)
-        try:
-            body = example._repr_html_()
-        except AttributeError:
-            body = repr(example)
-
-        return "<h5>%s - elements like<h5>\n%s" % (type(self).__name__, body)
-
-    def __add__(self, other):
-        return self.map_partitions(operator.add, other)
-
-    def __mul__(self, other):
-        return self.map_partitions(operator.mul, other)
-
-    def __mod__(self, other):
-        return self.map_partitions(operator.mod, other)
-
-    def __truediv__(self, other):
-        return self.map_partitions(operator.truediv, other)
-
-    def __floordiv__(self, other):
-        return self.map_partitions(operator.floordiv, other)
-
-    def emit(self, x):
-        self.verify(x)
-        self.stream.emit(x)
-
-    def verify(self, x):
-        if not isinstance(x, self._subtype):
-            raise TypeError("Expected type %s, got type %s" %
-                            (self._subtype, type(x)))
+    def round(self, decimals=0):
+        return self.map_partitions(M.round, decimals=decimals)
 
     def rolling(self, window, min_periods=1):
         if not isinstance(window, int):
@@ -99,14 +25,6 @@ class Streaming(object):
                             min_periods=min_periods, returns_state=True)
                       .filter(lambda x: len(x) >= min_periods))
         return type(self)(stream=stream, example=self.example)
-
-
-class StreamingFrame(Streaming):
-    def sum(self):
-        return self.accumulate_partitions(_accumulate_sum, start=0)
-
-    def round(self, decimals=0):
-        return self.map_partitions(M.round, decimals=decimals)
 
 
 class StreamingDataFrame(StreamingFrame):
@@ -304,3 +222,7 @@ def _roll(accumulator, new, window, min_periods):
 
     out = accumulator if len(accumulator) >= min_periods else []
     return accumulator, out
+
+
+_subtypes.append((pd.DataFrame, StreamingDataFrame))
+_subtypes.append((pd.Series, StreamingSeries))

--- a/streamz/dataframe.py
+++ b/streamz/dataframe.py
@@ -1,0 +1,306 @@
+from functools import partial
+import operator
+
+import streamz
+from streamz import Stream
+from dask.utils import M
+import pandas as pd
+
+
+class Streaming(object):
+    _subtype = object
+
+    def __init__(self, stream=None, example=None, columns=None):
+        if columns is not None and example is None:
+            example = pd.DataFrame({c: [] for c in columns})
+        assert example is not None
+        self.example = example
+        assert isinstance(self.example, self._subtype)
+        self.stream = stream or Stream()
+
+    def map_partitions(self, func, *args, **kwargs):
+        example = kwargs.pop('example', None)
+        if example is None:
+            example = func(self.example, *args, **kwargs)
+        stream = self.stream.map(func, *args, **kwargs)
+
+        if isinstance(example, pd.DataFrame):
+            return StreamingDataFrame(stream, example)
+        elif isinstance(example, pd.Series):
+            return StreamingSeries(stream, example)
+        else:
+            return Streaming(stream, example)
+
+    def accumulate_partitions(self, func, *args, **kwargs):
+        start = kwargs.pop('start', streamz.core.no_default)
+        returns_state = kwargs.pop('returns_state', False)
+        example = kwargs.pop('example', None)
+        if example is None:
+            example = func(start, self.example, *args, **kwargs)
+        if returns_state:
+            _, example = example
+        stream = self.stream.accumulate(func, *args, start=start,
+                returns_state=returns_state, **kwargs)
+
+        if isinstance(example, pd.DataFrame):
+            return StreamingDataFrame(stream, example)
+        elif isinstance(example, pd.Series):
+            return StreamingSeries(stream, example)
+        else:
+            return Streaming(stream, example)
+
+    def __repr__(self):
+        example = self.example
+        if hasattr(example, 'head'):
+            example = example.head(2)
+        return "%s - elements like:\n%r" % (type(self).__name__, example)
+
+    def _repr_html_(self):
+        example = self.example
+        if hasattr(example, 'head'):
+            example = example.head(2)
+        try:
+            body = example._repr_html_()
+        except AttributeError:
+            body = repr(example)
+
+        return "<h5>%s - elements like<h5>\n%s" % (type(self).__name__, body)
+
+    def __add__(self, other):
+        return self.map_partitions(operator.add, other)
+
+    def __mul__(self, other):
+        return self.map_partitions(operator.mul, other)
+
+    def __mod__(self, other):
+        return self.map_partitions(operator.mod, other)
+
+    def __truediv__(self, other):
+        return self.map_partitions(operator.truediv, other)
+
+    def __floordiv__(self, other):
+        return self.map_partitions(operator.floordiv, other)
+
+    def emit(self, x):
+        self.verify(x)
+        self.stream.emit(x)
+
+    def verify(self, x):
+        if not isinstance(x, self._subtype):
+            raise TypeError("Expected type %s, got type %s" %
+                            (self._subtype, type(x)))
+
+    def rolling(self, window, min_periods=1):
+        if not isinstance(window, int):
+            window = pd.Timedelta(window)
+            min_periods = 1
+        stream = (self.stream
+                      .scan(_roll, window=window,
+                            min_periods=min_periods, returns_state=True)
+                      .filter(lambda x: len(x) >= min_periods))
+        return type(self)(stream=stream, example=self.example)
+
+
+class StreamingFrame(Streaming):
+    def sum(self):
+        return self.accumulate_partitions(_accumulate_sum, start=0)
+
+    def round(self, decimals=0):
+        return self.map_partitions(M.round, decimals=decimals)
+
+
+class StreamingDataFrame(StreamingFrame):
+    _subtype = pd.DataFrame
+
+    @property
+    def columns(self):
+        return self.example.columns
+
+    def __getitem__(self, index):
+        return self.map_partitions(operator.getitem, index)
+
+    def __getattr__(self, key):
+        if key in self.columns:
+            return self.map_partitions(getattr, key)
+        else:
+            raise AttributeError("StreamingDataFrame has no attribute %r" % key)
+
+    def __dir__(self):
+        o = set(dir(type(self)))
+        o.update(self.__dict__)
+        o.update(c for c in self.columns if
+                 (isinstance(c, pd.compat.string_types) and
+                 pd.compat.isidentifier(c)))
+        return list(o)
+
+    def verify(self, x):
+        super(StreamingDataFrame, self).verify(x)
+        if list(x.columns) != list(self.example.columns):
+            raise IndexError("Input expected to have columns %s, got %s" %
+                             (self.example.columns, x.columns))
+
+    def mean(self):
+        start = pd.DataFrame({'sums': 0, 'counts': 0},
+                             index=self.example.columns)
+        return self.accumulate_partitions(_accumulate_mean, start=start,
+                                          returns_state=True)
+
+    def groupby(self, other):
+        return StreamingSeriesGroupby(self, other)
+
+    def assign(self, **kwargs):
+        def concat(tup, columns=None):
+            result = pd.concat(tup, axis=1)
+            result.columns = columns
+            return result
+        columns, values = zip(*kwargs.items())
+        stream = self.stream.zip(*[v.stream for v in values])
+        stream = stream.map(concat, columns=list(self.columns) + list(columns))
+        example = self.example.assign(**{c: v.example for c, v in kwargs.items()})
+        return StreamingDataFrame(stream, example)
+
+    def __setitem__(self, key, value):
+        if isinstance(value, StreamingSeries):
+            result = self.assign(**{key: value})
+        elif isinstance(value, StreamingDataFrame):
+            result = self.assign(**{k: value[c] for k, c in zip(key, value.columns)})
+        else:
+            example = self.example.copy()
+            example[key] = value
+            result = self.map_partitions(pd.DataFrame.assign, **{key: value})
+
+        self.stream = result.stream
+        self.example = result.example
+        return self
+
+
+class StreamingSeries(StreamingFrame):
+    _subtype = pd.Series
+
+    def mean(self):
+        start = pd.Series({'sums': 0, 'counts': 0})
+        return self.accumulate_partitions(_accumulate_mean, start=start,
+                                          returns_state=True)
+
+
+def _accumulate_mean(accumulator, new):
+    accumulator = accumulator.copy()
+    accumulator['sums'] += new.sum()
+    accumulator['counts'] += new.count()
+    result = accumulator['sums'] / accumulator['counts']
+    return accumulator, result
+
+
+def _accumulate_sum(accumulator, new):
+    return accumulator + new.sum()
+
+
+def _accumulate_size(accumulator, new):
+    return accumulator + new.size()
+
+
+class StreamingSeriesGroupby(object):
+    def __init__(self, root, grouper, index=None):
+        self.root = root
+        self.grouper = grouper
+        self.index = index
+
+    def __getitem__(self, index):
+        return StreamingSeriesGroupby(self.root, self.grouper, index)
+
+    def __getattr__(self, key):
+        if key in self.root.columns:
+            return self[key]
+        else:
+            raise AttributeError("StreamingSeriesGroupby has no attribute %r" % key)
+
+    def sum(self):
+        func = _accumulate_groupby_sum
+        start = 0
+        if isinstance(self.grouper, Streaming):
+            func = partial(func, index=self.index)
+            example = self.root.example.groupby(self.grouper.example)
+            if self.index is not None:
+                example = example[self.index]
+            example = example.sum()
+            stream = self.root.stream.zip(self.grouper.stream)
+            stream = stream.accumulate(func, start=start)
+        else:
+            func = partial(func, grouper=self.grouper, index=self.index)
+            example = self.root.example.groupby(self.grouper)
+            if self.index is not None:
+                example = example[self.index]
+            example = example.sum()
+            stream = self.root.stream.accumulate(func, start=start)
+        if isinstance(example, pd.DataFrame):
+            return StreamingDataFrame(stream, example)
+        else:
+            return StreamingSeries(stream, example)
+
+    def mean(self):
+        # TODO, there is a lot of copy-paste with the code above
+        # TODO, we should probably define groupby.aggregate
+        func = _accumulate_groupby_mean
+        start = (0, 0)
+        if isinstance(self.grouper, Streaming):
+            func = partial(func, index=self.index)
+            example = self.root.example.groupby(self.grouper.example)
+            if self.index is not None:
+                example = example[self.index]
+            example = example.mean()
+            stream = self.root.stream.zip(self.grouper.stream)
+            stream = stream.accumulate(func, start=start, returns_state=True)
+        else:
+            func = partial(func, grouper=self.grouper, index=self.index)
+            example = self.root.example.groupby(self.grouper)
+            if self.index is not None:
+                example = example[self.index]
+            example = example.mean()
+            stream = self.root.stream.accumulate(func, start=start,
+                                                 returns_state=True)
+        if isinstance(example, pd.DataFrame):
+            return StreamingDataFrame(stream, example)
+        else:
+            return StreamingSeries(stream, example)
+
+
+def _accumulate_groupby_sum(accumulator, new, grouper=None, index=None):
+    if isinstance(new, tuple):  # zipped
+        assert grouper is None
+        new, grouper = new
+    g = new.groupby(grouper)
+    if index is not None:
+        g = g[index]
+    if isinstance(accumulator, int):
+        return g.sum()
+    else:
+        return accumulator.add(g.sum(), fill_value=0)
+
+
+def _accumulate_groupby_mean(accumulator, new, grouper=None, index=None):
+    if isinstance(new, tuple):  # zipped
+        assert grouper is None
+        new, grouper = new
+    g = new.groupby(grouper)
+    if index is not None:
+        g = g[index]
+
+    (sums, counts) = accumulator
+    if isinstance(sums, int):  # first time
+        sums = g.sum()
+        counts = g.count()
+    else:
+        sums = sums.add(g.sum(), fill_value=0)
+        counts = counts.add(g.count(), fill_value=0)
+    return (sums, counts), sums / counts
+
+
+def _roll(accumulator, new, window, min_periods):
+    accumulator = pd.concat([accumulator, new])
+    if isinstance(window, int):
+        accumulator = accumulator.iloc[-window:]
+    elif isinstance(window, pd.Timedelta):
+        accumulator = accumulator.loc[(accumulator.index.max() - window):]
+
+    out = accumulator if len(accumulator) >= min_periods else []
+    return accumulator, out

--- a/streamz/dataframe.py
+++ b/streamz/dataframe.py
@@ -1,8 +1,6 @@
 from functools import partial
 import operator
 
-import streamz
-from streamz import Stream
 from dask.utils import M
 import pandas as pd
 

--- a/streamz/dataframe.py
+++ b/streamz/dataframe.py
@@ -36,7 +36,7 @@ class StreamingDataFrame(StreamingFrame):
         return self.map_partitions(operator.getitem, index)
 
     def __getattr__(self, key):
-        if key in self.columns:
+        if key in self.columns or not len(self.columns):
             return self.map_partitions(getattr, key)
         else:
             raise AttributeError("StreamingDataFrame has no attribute %r" % key)
@@ -125,7 +125,7 @@ class StreamingSeriesGroupby(object):
         return StreamingSeriesGroupby(self.root, self.grouper, index)
 
     def __getattr__(self, key):
-        if key in self.root.columns:
+        if key in self.root.columns or not len(self.root.columns):
             return self[key]
         else:
             raise AttributeError("StreamingSeriesGroupby has no attribute %r" % key)

--- a/streamz/dataframe.py
+++ b/streamz/dataframe.py
@@ -26,6 +26,17 @@ class StreamingFrame(Streaming):
 
 
 class StreamingDataFrame(StreamingFrame):
+    """ A Streaming dataframe
+
+    This is a logical collection over a stream of Pandas dataframes.
+    Operations on this object will translate to the appropriate operations on
+    the underlying Pandas dataframes.
+
+    See Also
+    --------
+    streams.dataframe.StreamingSeries
+    streams.sequence.StreamingSequence
+    """
     _subtype = pd.DataFrame
 
     @property
@@ -91,6 +102,17 @@ class StreamingDataFrame(StreamingFrame):
 
 
 class StreamingSeries(StreamingFrame):
+    """ A Streaming series
+
+    This is a logical collection over a stream of Pandas series objects.
+    Operations on this object will translate to the appropriate operations on
+    the underlying Pandas series.
+
+    See Also
+    --------
+    streams.dataframe.StreamingDataFrame
+    streams.sequence.StreamingSequence
+    """
     _subtype = pd.Series
 
     def mean(self):

--- a/streamz/sequence.py
+++ b/streamz/sequence.py
@@ -34,6 +34,7 @@ class StreamingSequence(Streaming):
 
     def to_dataframe(self):
         import pandas as pd
+        import streamz.dataframe
         return self.map_partitions(pd.DataFrame)
 
 

--- a/streamz/sequence.py
+++ b/streamz/sequence.py
@@ -1,0 +1,54 @@
+from .collection import Streaming, _subtypes
+import toolz
+import toolz.curried
+
+
+class StreamingSequence(Streaming):
+    """ A Stream of Sequences
+
+    This streaming collection manages batches of Python objects such as lists
+    of text or dictionaries.  By batching many elements together we reduce
+    overhead from Python.
+
+    This library is typically used at the early stages of data ingestion before
+    handing off to streaming dataframes
+
+    Examples
+    --------
+    >>> text = Streaming.from_file(myfile)
+    >>> sdf = text.map(json.loads).to_dataframe()
+    """
+    def __init__(self, stream=None, example=None):
+        if example is None:
+            example = []
+        super(StreamingSequence, self).__init__(stream=stream, example=example)
+
+    def sum(self):
+        return self.accumulate_partitions(_accumulate_sum, start=0)
+
+    def pluck(self, ind):
+        return self.map_partitions(_pluck, ind)
+
+    def map(self, func, **kwargs):
+        return self.map_partitions(_map_map, func, **kwargs)
+
+    def to_dataframe(self):
+        import pandas as pd
+        return self.map_partitions(pd.DataFrame)
+
+
+def _pluck(seq, ind):
+    return list(toolz.pluck(ind, seq))
+
+
+def _map_map(seq, func, **kwargs):
+    return list(map(func, seq, **kwargs))
+
+
+def _accumulate_sum(accumulator, new):
+    return accumulator + sum(new)
+
+
+map_type = type(map(lambda x: x, []))
+
+_subtypes.append(((list, tuple, set), StreamingSequence))

--- a/streamz/sequence.py
+++ b/streamz/sequence.py
@@ -34,7 +34,7 @@ class StreamingSequence(Streaming):
 
     def to_dataframe(self):
         import pandas as pd
-        import streamz.dataframe
+        import streamz.dataframe  # flake8: noqa
         return self.map_partitions(pd.DataFrame)
 
 

--- a/streamz/tests/test_dataframes.py
+++ b/streamz/tests/test_dataframes.py
@@ -156,7 +156,7 @@ def test_repr_html():
     for x in [a, a.y, a.y.mean()]:
         html = x._repr_html_()
         assert type(x).__name__ in html
-        assert '1.0' in html
+        assert '1' in html
 
 
 def test_setitem():

--- a/streamz/tests/test_dataframes.py
+++ b/streamz/tests/test_dataframes.py
@@ -9,10 +9,10 @@ import pandas.util.testing as tm
 
 
 def test_identity():
-    sdf = StreamingDataFrame(columns=['x', 'y'])
+    df = pd.DataFrame({'x': [1, 2, 3], 'y': [4, 5, 6]})
+    sdf = StreamingDataFrame(example=df)
     L = sdf.stream.sink_to_list()
 
-    df = pd.DataFrame({'x': [1, 2, 3], 'y': [4, 5, 6]})
     sdf.emit(df)
 
     assert L[0] is df
@@ -29,7 +29,8 @@ def test_identity():
 
 
 def test_exceptions():
-    sdf = StreamingDataFrame(columns=['x', 'y'])
+    df = pd.DataFrame({'x': [1, 2, 3], 'y': [4, 5, 6]})
+    sdf = StreamingDataFrame(example=df)
     with pytest.raises(TypeError):
         sdf.emit(1)
 
@@ -38,7 +39,8 @@ def test_exceptions():
 
 
 def test_sum():
-    sdf = StreamingDataFrame(columns=['x', 'y'])
+    df = pd.DataFrame({'x': [1, 2, 3], 'y': [4, 5, 6]})
+    sdf = StreamingDataFrame(example=df)
     df_out = sdf.sum().stream.sink_to_list()
 
     x = sdf.x
@@ -56,7 +58,8 @@ def test_sum():
 
 
 def test_mean():
-    sdf = StreamingDataFrame(columns=['x', 'y'])
+    df = pd.DataFrame({'x': [1, 2, 3], 'y': [4, 5, 6]})
+    sdf = StreamingDataFrame(example=df)
     mean = sdf.mean()
     assert isinstance(mean, StreamingSeries)
     df_out = mean.stream.sink_to_list()
@@ -76,7 +79,8 @@ def test_mean():
 
 
 def test_arithmetic():
-    a = StreamingDataFrame(columns=['x', 'y'])
+    df = pd.DataFrame({'x': [1, 2, 3], 'y': [4, 5, 6]})
+    a = StreamingDataFrame(example=df)
     b = a + 1
 
     L1 = b.stream.sink_to_list()

--- a/streamz/tests/test_dataframes.py
+++ b/streamz/tests/test_dataframes.py
@@ -1,0 +1,217 @@
+import time
+
+from streamz.dataframe import StreamingDataFrame, StreamingSeries
+import pytest
+from dask.dataframe.utils import assert_eq
+import numpy as np
+import pandas as pd
+import pandas.util.testing as tm
+
+
+def test_identity():
+    sdf = StreamingDataFrame(columns=['x', 'y'])
+    L = sdf.stream.sink_to_list()
+
+    df = pd.DataFrame({'x': [1, 2, 3], 'y': [4, 5, 6]})
+    sdf.emit(df)
+
+    assert L[0] is df
+    assert list(sdf.example.columns) == ['x', 'y']
+
+    x = sdf.x
+    assert isinstance(x, StreamingSeries)
+    L2 = x.stream.sink_to_list()
+    assert not L2
+
+    sdf.emit(df)
+    assert isinstance(L2[0], pd.Series)
+    assert assert_eq(L2[0], df.x)
+
+
+def test_exceptions():
+    sdf = StreamingDataFrame(columns=['x', 'y'])
+    with pytest.raises(TypeError):
+        sdf.emit(1)
+
+    with pytest.raises(IndexError):
+        sdf.emit(pd.DataFrame())
+
+
+def test_sum():
+    sdf = StreamingDataFrame(columns=['x', 'y'])
+    df_out = sdf.sum().stream.sink_to_list()
+
+    x = sdf.x
+    x_out = (x.sum() + 1).stream.sink_to_list()
+
+    df = pd.DataFrame({'x': [1, 2, 3], 'y': [4, 5, 6]})
+    sdf.emit(df)
+    sdf.emit(df)
+
+    assert assert_eq(df_out[0], df.sum())
+    assert assert_eq(df_out[1], df.sum() + df.sum())
+
+    assert x_out[0] == df.x.sum() + 1
+    assert x_out[1] == df.x.sum() + df.x.sum() + 1
+
+
+def test_mean():
+    sdf = StreamingDataFrame(columns=['x', 'y'])
+    mean = sdf.mean()
+    assert isinstance(mean, StreamingSeries)
+    df_out = mean.stream.sink_to_list()
+
+    x = sdf.x
+    x_out = x.mean().stream.sink_to_list()
+
+    df = pd.DataFrame({'x': [1, 2, 3], 'y': [4, 5, 6]})
+    sdf.emit(df)
+    sdf.emit(df)
+
+    assert assert_eq(df_out[0], df.mean())
+    assert assert_eq(df_out[1], df.mean())
+
+    assert x_out[0] == df.x.mean()
+    assert x_out[1] == df.x.mean()
+
+
+def test_arithmetic():
+    a = StreamingDataFrame(columns=['x', 'y'])
+    b = a + 1
+
+    L1 = b.stream.sink_to_list()
+
+    c = b.x * 10
+
+    L2 = c.stream.sink_to_list()
+
+    df = pd.DataFrame({'x': [1, 2, 3], 'y': [4, 5, 6]})
+    a.emit(df)
+
+    assert assert_eq(L1[0], df + 1)
+    assert assert_eq(L2[0], (df + 1).x * 10)
+
+
+@pytest.mark.xfail(reason='need to zip two streaming dataframes together')
+def test_pair_arithmetic():
+    df = pd.DataFrame({'x': list(range(10)), 'y': [1] * 10})
+
+    a = StreamingDataFrame(example=df.iloc[0])
+    L = ((a.x + a.y) * 2).sink_to_list()
+
+    a.emit(df.iloc[:5])
+    a.emit(df.iloc[5:])
+
+    assert len(L) == 2
+    assert_eq(pd.concat(L, axis=0), (df.x + df.y) * 2)
+
+
+@pytest.mark.parametrize('agg', ['sum', 'mean'])
+@pytest.mark.parametrize('grouper', [lambda a: a.x % 3,
+                                     lambda a: 'x',
+                                     lambda a: ['x']])
+@pytest.mark.parametrize('indexer', [lambda g: g.y,
+                                     lambda g: g,
+                                     lambda g: g[['y']],
+                                     lambda g: g[['x', 'y']]])
+def test_groupby_aggregate(agg, grouper, indexer):
+    df = pd.DataFrame({'x': (np.arange(10) // 2).astype(float), 'y': [1.0] * 10})
+
+    a = StreamingDataFrame(example=df.iloc[:0])
+
+    L = getattr(indexer(a.groupby(grouper(a))), agg)().stream.sink_to_list()
+
+    a.emit(df.iloc[:3])
+    a.emit(df.iloc[3:7])
+    a.emit(df.iloc[7:])
+
+    assert assert_eq(L[-1], getattr(indexer(df.groupby(grouper(df))), agg)())
+
+
+def test_repr():
+    df = pd.DataFrame({'x': (np.arange(10) // 2).astype(float), 'y': [1.0] * 10})
+    a = StreamingDataFrame(example=df)
+
+    text = repr(a)
+    assert type(a).__name__ in text
+    assert 'x' in text
+    assert 'y' in text
+
+    text = repr(a.x)
+    assert type(a.x).__name__ in text
+    assert 'x' in text
+
+    text = repr(a.x.sum())
+    assert type(a.x.sum()).__name__ in text
+
+
+def test_repr_html():
+    df = pd.DataFrame({'x': (np.arange(10) // 2).astype(float), 'y': [1.0] * 10})
+    a = StreamingDataFrame(example=df)
+
+    for x in [a, a.y, a.y.mean()]:
+        html = x._repr_html_()
+        assert type(x).__name__ in html
+        assert '1.0' in html
+
+
+def test_setitem():
+    df = pd.DataFrame({'x': list(range(10)), 'y': [1] * 10})
+
+    sdf = StreamingDataFrame(example=df.iloc[:0])
+    stream = sdf.stream
+
+    sdf['z'] = sdf['x'] * 2
+    sdf['a'] = 10
+    sdf[['c', 'd']] = sdf[['x', 'y']]
+
+    L = sdf.mean().stream.sink_to_list()
+
+    stream.emit(df.iloc[:3])
+    stream.emit(df.iloc[3:7])
+    stream.emit(df.iloc[7:])
+
+    df['z'] = df['x'] * 2
+    df['a'] = 10
+    df[['c', 'd']] = df[['x', 'y']]
+
+    assert_eq(L[-1], df.mean())
+
+
+def test_rolling():
+    df = pd.DataFrame({'x': [1, 2, 3], 'y': [4, 5, 6]})
+
+    sdf = StreamingDataFrame(example=df)
+    out = sdf.rolling(3, min_periods=2)
+    L = out.stream.sink_to_list()
+
+    for i in range(10):
+        df = pd.DataFrame({'x': [i], 'y': [i + 1]})
+        sdf.emit(df)
+
+    assert len(L) == 9
+    assert all(len(df) >= 2 for df in L)
+    for i, df in enumerate(L[1:]):
+        expected = pd.DataFrame({'x': [i, i + 1, i + 2],
+                                 'y': [i + 1, i + 2, i + 3]})
+        tm.assert_frame_equal(df.reset_index(drop=True), expected)
+
+
+def test_rolling_time():
+    now = pd.Timestamp.now()
+    df = pd.DataFrame({'x': [1], 'y': [4]},
+                      index=[now])
+
+    sdf = StreamingDataFrame(example=df)
+    L = sdf.rolling('10ms').stream.sink_to_list()
+
+    for i in range(100):
+        df = pd.DataFrame({'x': [i, i + 0.5], 'y': [i, i + 0.5]},
+                          index=[pd.Timestamp.now(), pd.Timestamp.now()])
+        sdf.emit(df)
+        time.sleep(0.001)
+
+    assert L
+    for df in L[3:]:
+        assert df.index.max() - df.index.min() < pd.Timedelta('10ms')
+        assert df.index.max() - df.index.min() > pd.Timedelta('1ms')

--- a/streamz/tests/test_dataframes.py
+++ b/streamz/tests/test_dataframes.py
@@ -224,6 +224,18 @@ def test_rolling_time():
         assert df.index.max() - df.index.min() > pd.Timedelta('1ms')
 
 
+def test_stream_to_dataframe():
+    df = pd.DataFrame({'x': [1, 2, 3], 'y': [4, 5, 6]})
+    source = Stream()
+    L = source.to_dataframe(example=df).x.sum().stream.sink_to_list()
+
+    source.emit(df)
+    source.emit(df)
+    source.emit(df)
+
+    assert L == [6, 12, 18]
+
+
 def test_integration_from_stream():
     source = Stream()
     sdf = source.partition(4).to_sequence(example=['{"x": 0, "y": 0}']).map(json.loads).to_dataframe()
@@ -233,4 +245,4 @@ def test_integration_from_stream():
     for i in range(12):
         source.emit(json.dumps({'x': i % 3, 'y': i}))
 
-    assert L == [2, 17/3, 100 / 9]
+    assert L == [2, 17 / 3, 100 / 9]

--- a/streamz/tests/test_sequence.py
+++ b/streamz/tests/test_sequence.py
@@ -1,0 +1,37 @@
+import pytest
+import toolz
+
+from streamz.sequence import StreamingSequence, Streaming
+from streamz.utils_test import inc
+
+
+def test_core():
+    a = StreamingSequence()
+    b = a.pluck('x').map(inc)
+    c = b.sum()
+    L = c.stream.sink_to_list()
+
+    a.emit([{'x': i, 'y': 0} for i in range(4)])
+
+    assert isinstance(b, StreamingSequence)
+    assert isinstance(c, Streaming)
+    assert L == [1 + 2 + 3 + 4]
+
+
+def test_dataframes():
+    pd = pytest.importorskip('pandas')
+    from streamz.dataframe import StreamingDataFrame
+    data = [{'x': i, 'y': 2 * i} for i in range(10)]
+
+    s = StreamingSequence(example=[{'x': 0, 'y': 0}])
+    sdf = s.map(lambda d: toolz.assoc(d, 'z', d['x'] + d['y'])).to_dataframe()
+
+    assert isinstance(sdf, StreamingDataFrame)
+
+    L = sdf.stream.sink_to_list()
+
+    for batch in toolz.partition_all(3, data):
+        s.emit(batch)
+
+    result = pd.concat(L)
+    assert result.z.tolist() == [3 * i for i in range(10)]

--- a/streamz/utils.py
+++ b/streamz/utils.py
@@ -1,0 +1,51 @@
+
+
+_method_cache = {}
+
+
+class methodcaller(object):
+    """
+    Return a callable object that calls the given method on its operand.
+
+    Unlike the builtin `operator.methodcaller`, instances of this class are
+    serializable
+    """
+
+    __slots__ = ('method',)
+    func = property(lambda self: self.method)  # For `funcname` to work
+
+    def __new__(cls, method):
+        if method in _method_cache:
+            return _method_cache[method]
+        self = object.__new__(cls)
+        self.method = method
+        _method_cache[method] = self
+        return self
+
+    def __call__(self, obj, *args, **kwargs):
+        return getattr(obj, self.method)(*args, **kwargs)
+
+    def __reduce__(self):
+        return (methodcaller, (self.method,))
+
+    def __str__(self):
+        return "<%s: %s>" % (self.__class__.__name__, self.method)
+
+    __repr__ = __str__
+
+
+class MethodCache(object):
+    """Attribute access on this object returns a methodcaller for that
+    attribute.
+
+    Examples
+    --------
+    >>> a = [1, 3, 3]
+    >>> M.count(a, 3) == a.count(3)
+    True
+    """
+    __getattr__ = staticmethod(methodcaller)
+    __dir__ = lambda self: list(_method_cache)
+
+
+M = MethodCache()

--- a/streamz/utils_test.py
+++ b/streamz/utils_test.py
@@ -26,6 +26,21 @@ def tmpfile(extension=''):
                 pass
 
 
+@contextmanager
+def filetext(text, extension='', open=open, mode='w'):
+    with tmpfile(extension=extension) as filename:
+        f = open(filename, mode=mode)
+        try:
+            f.write(text)
+        finally:
+            try:
+                f.close()
+            except AttributeError:
+                pass
+
+        yield filename
+
+
 def inc(x):
     return x + 1
 


### PR DESCRIPTION
This adds streaming collections for lists and pandas dataframes.  

This merges work from the experimental [pandas-streaming](https://github.com/dask/pandas-streaming) project, refactors it to remove common subcomponents, and then builds on those components to build a similar (though much less fully featured) system for lists/batches of elements.