### PR TITLE
Register methods with Stream.register_api decorator

### DIFF
--- a/streamz/tests/test_core.py
+++ b/streamz/tests/test_core.py
@@ -684,3 +684,27 @@ def test_from_file():
             yield gen.sleep(0.050)
 
             assert L == [1, 2, 3, 4, 5]
+
+
+def test_docstrings():
+    for s in [Stream, Stream()]:
+        assert 'every element' in s.map.__doc__
+        assert s.map.__name__ == 'map'
+        assert 'predicate' in s.filter.__doc__
+        assert s.filter.__name__ == 'filter'
+
+
+def test_subclass():
+    class NewStream(Stream):
+        pass
+
+    @NewStream.register_api
+    class foo(NewStream):
+        pass
+
+    assert hasattr(NewStream, 'map')
+    assert hasattr(NewStream(), 'map')
+    assert hasattr(NewStream, 'foo')
+    assert hasattr(NewStream(), 'foo')
+    assert not hasattr(Stream, 'foo')
+    assert not hasattr(Stream(), 'foo')


### PR DESCRIPTION
This moves methods off of the main stream class and offers an opportunity for
extension without subclassing.

People want to build their own operations for streams. The obvious way to do
this, subclassing, is hard due to how we have laid things out.  As an
alternative we consider function dispatch.  This also helps to reduce
boiler-plate, although it also adds some complexity and indirection.

Currently we define operations like `map` as a separate class and then add a
special method:

```python
class Stream(object):
    ...
    def map(...):
        return map(...

class map(Stream):
    ...
```

This is bad for two reasons:

1.  The map method is somewhat redundant
2.  We have hard coded all valid operations.  It's hard to add new ones.

As an alternative we dynamically add methods to stream with a decorator

```python
class Stream(object):
    @classmethod
    def register_api(cls, func):
        ...

@Stream.register_api
class map(Stream):
    ...
```

cc @CJ-Wright, @ordirules and @limx0 for feedback.

cc @eriknw for help with wrapping effectively if he has the time.  Currently we lose function names and docstrings (see failing `test_docstrings` test).