### PR TITLE
Graph and string styling

### DIFF
--- a/streamz/core.py
+++ b/streamz/core.py
@@ -491,8 +491,8 @@ class Stream(object):
         from .sequence import StreamingSequence
         return StreamingSequence(stream=self, **kwargs)
 
-    @gen.coroutine
-    def from_textfile(self, f, poll_interval=None):
+    @staticmethod
+    def from_textfile(f, poll_interval=None):
         """ Read data from file into stream
 
         Parameters
@@ -513,19 +513,8 @@ class Stream(object):
         -------
         Nothing.  This has the side effect of emitting data into the stream.
         """
-        if isinstance(f, str):
-            f = open(f)
-
-        while True:
-            line = f.readline()
-            if line:
-                last = self.emit(line)  # TODO: we should yield on emit
-            else:
-                if poll_interval:
-                    yield gen.sleep(poll_interval)
-                    yield last
-                else:
-                    return
+        from .sources import TextFile
+        return TextFile(f, poll_interval=poll_interval)
 
 
 class Sink(Stream):

--- a/streamz/core.py
+++ b/streamz/core.py
@@ -52,6 +52,11 @@ class Stream(object):
     >>> L  # and the actions happen at the sinks
     ['1', '2', '3', '4', '5']
     """
+    _graphviz_shape = 'ellipse'
+    _graphviz_style = 'rounded,filled'
+    _graphviz_fillcolor = 'white'
+    _graphviz_orientation = 0
+
     str_list = ['func', 'predicate', 'n', 'interval']
 
     def __init__(self, child=None, children=None, stream_name=None, **kwargs):
@@ -88,9 +93,16 @@ class Stream(object):
                     s = None
             if s:
                 s_list.append('{}={}'.format(m, s))
-        s = "; ".join(s_list)
-        s = "<" + s + ">"
-        return s
+        if len(s_list) <= 2:
+            s_list = [term.split('=')[-1] for term in s_list]
+
+        text = "<"
+        text += s_list[0]
+        if len(s_list) > 1:
+            text += ': '
+            text += ', '.join(s_list[1:])
+        text += '>'
+        return text
 
     def emit(self, x):
         """ Push data into the stream at this point
@@ -518,6 +530,8 @@ class Stream(object):
 
 
 class Sink(Stream):
+    _graphviz_shape = 'invtrapezium'
+
     def __init__(self, func, child):
         self.func = func
 
@@ -564,6 +578,8 @@ class filter(Stream):
 
 
 class scan(Stream):
+    _graphviz_shape = 'box'
+
     def __init__(self, func, child, start=no_default, returns_state=False,
                  **kwargs):
         self.func = func
@@ -697,6 +713,9 @@ class buffer(Stream):
 
 
 class zip(Stream):
+    _graphviz_orientation = 270
+    _graphviz_shape = 'triangle'
+
     def __init__(self, *children, **kwargs):
         self.maxsize = kwargs.pop('maxsize', 10)
         self.buffers = [deque() for _ in children]

--- a/streamz/graph.py
+++ b/streamz/graph.py
@@ -16,7 +16,12 @@ def create_graph(node, graph, prior_node=None, pc=None):
     if node is None:
         return
     t = hash(node)
-    graph.add_node(t, str=str(node))
+    graph.add_node(t,
+                   label=str(node).replace(':', ';'),
+                   shape=node._graphviz_shape,
+                   orientation=str(node._graphviz_orientation),
+                   style=node._graphviz_style,
+                   fillcolor=node._graphviz_fillcolor)
     if prior_node:
         tt = hash(prior_node)
         if graph.has_edge(t, tt):
@@ -44,7 +49,7 @@ def readable_graph(node):
     import networkx as nx
     g = nx.DiGraph()
     create_graph(node, g)
-    mapping = {k: '{}'.format(g.node[k]['str']) for k in g}
+    mapping = {k: '{}'.format(g.node[k]['label']) for k in g}
     idx_mapping = {}
     for k, v in mapping.items():
         if v in idx_mapping.keys():
@@ -61,8 +66,8 @@ def readable_graph(node):
 def to_graphviz(graph, **graph_attr):
     import graphviz
     gvz = graphviz.Digraph(graph_attr=graph_attr)
-    for node in graph.nodes():
-        gvz.node(node)
+    for node, attrs in graph.node.items():
+        gvz.node(node, **attrs)
     gvz.edges(graph.edges())
     return gvz
 

--- a/streamz/sources.py
+++ b/streamz/sources.py
@@ -1,5 +1,6 @@
 from .core import Stream, Sink
 import tornado.ioloop
+from tornado import gen
 
 
 def PeriodicCallback(callback, callback_time, **kwargs):
@@ -24,3 +25,45 @@ def sink_to_file(filename, child, mode='w', prefix='', suffix='\n', flush=False)
 
     Sink(write, child)
     return file
+
+
+class TextFile(Stream):
+    """ Stream data from a text file
+
+    Parameters
+    ----------
+    f: file or string
+    poll_interval: Number
+        Interval to poll file for new data in seconds
+
+    Example
+    -------
+    >>> source = Stream.from_textfile('myfile.json')  # doctest: +SKIP
+    >>> js.map(json.loads).pluck('value').sum().sink(print)  # doctest: +SKIP
+
+    >>> source.start()  # doctest: +SKIP
+
+    Returns
+    -------
+    Stream
+    """
+    def __init__(self, f, poll_interval=0.100):
+        if isinstance(f, str):
+            f = open(f)
+        self.file = f
+
+        self.poll_interval = poll_interval
+        super(TextFile, self).__init__()
+
+    @gen.coroutine
+    def start(self):
+        while True:
+            line = self.file.readline()
+            if line:
+                last = self.emit(line)  # TODO: we should yield on emit
+            else:
+                if self.poll_interval:
+                    yield gen.sleep(self.poll_interval)
+                    yield last
+                else:
+                    return

--- a/streamz/sources.py
+++ b/streamz/sources.py
@@ -27,7 +27,11 @@ def sink_to_file(filename, child, mode='w', prefix='', suffix='\n', flush=False)
     return file
 
 
-class TextFile(Stream):
+class Source(Stream):
+    _graphviz_shape = 'doubleoctagon'
+
+
+class TextFile(Source):
     """ Stream data from a text file
 
     Parameters

--- a/streamz/tests/test_core.py
+++ b/streamz/tests/test_core.py
@@ -668,12 +668,13 @@ def test_from_file():
             f.write('{"x": 3, "y": 2}\n')
             f.flush()
 
-            source = Stream()
+            source = Stream.from_textfile(fn, poll_interval=0.010)
             L = source.map(json.loads).pluck('x').sink_to_list()
 
             assert L == []
 
-            source.from_textfile(fn, poll_interval=0.010)
+            source.start()
+
             assert L == [1, 2, 3]
 
             f.write('{"x": 4, "y": 2}\n')

--- a/streamz/tests/test_core.py
+++ b/streamz/tests/test_core.py
@@ -517,28 +517,28 @@ def test_map_str():
 
     source = Stream()
     s = source.map(add, y=10)
-    assert str(s) == '<map; func=add>'
+    assert str(s) == '<map: add>'
 
 
 def test_filter_str():
-    def add(x=0, y=0):
-        return x + y
+    def iseven(x):
+        return x % 2 == 0
 
     source = Stream()
-    s = source.filter(add)
-    assert str(s) == '<filter; predicate=add>'
+    s = source.filter(iseven)
+    assert str(s) == '<filter: iseven>'
 
 
 def test_timed_window_str():
     source = Stream()
     s = source.timed_window(.05)
-    assert str(s) == '<timed_window; interval=0.05>'
+    assert str(s) == '<timed_window: 0.05>'
 
 
 def test_partition_str():
     source = Stream()
     s = source.partition(2)
-    assert str(s) == '<partition; n=2>'
+    assert str(s) == '<partition: 2>'
 
 
 def test_stream_name_str():

--- a/streamz/tests/test_graph.py
+++ b/streamz/tests/test_graph.py
@@ -1,4 +1,4 @@
-from operator import add
+from operator import add, mul
 import os
 
 import pytest
@@ -27,7 +27,7 @@ def test_create_file():
     source2 = Stream(stream_name='source2')
 
     n1 = source1.zip(source2)
-    n2 = n1.map(add)
+    n2 = n1.map(add).scan(mul)
     n2.sink(source1.emit)
 
     with tmpfile(extension='png') as fn:
@@ -43,5 +43,6 @@ def test_create_file():
         with open(fn) as f:
             text = f.read()
 
-        for word in ['rankdir', 'source1', 'source2', 'zip', 'map', 'add']:
+        for word in ['rankdir', 'source1', 'source2', 'zip', 'map', 'add',
+                     'shape=box', 'shape=ellipse']:
             assert word in text


### PR DESCRIPTION
Modify visual styling for graph and string repr
    
We add graphviz attributes to the Stream classes directly (I'm not sure how I feel about this generally, but for now it seems productive).

```python   
class Foo(Stream):
    _graphviz_shape = 'box'
```

We remove the name from string reprs
    
    <map; func=inc>  # before
    <map: inc>       # after

### Example

```python
from streamz import Stream

def inc(x):
    return x + 1

def dec(x):
    return x - 1

import operator

source = Stream.from_textfile('foo.txt')
a = source.map(inc)
b = source.map(dec)
c = a.zip(b).scan(operator.add).sink(print)
c

c.visualize(rankdir='LR')
```

![image](https://user-images.githubusercontent.com/306380/31102192-0e960846-a79f-11e7-8a1a-9a95d9b5ca02.png)
