### PR TITLE
Support synchronous workloads in streamz

### DIFF
--- a/docs/source/async.rst
+++ b/docs/source/async.rst
@@ -1,0 +1,189 @@
+Asynchronous and Synchronous Computation
+========================================
+
+*This section is only relevant if you want to use time-based functionality.  If
+you are only using operations like map and accumulate then you can safely skip
+this section.*
+
+When using time-based flow control like ``rate_limit``, ``delay``, or
+``timed_window`` Streamz relies on the Tornado_ framework for concurrency.
+This allows us to handle many conncurent processes cheaply and consistently
+within a single thread.  However, this also adds complexity and requires some
+understanding of asynchronous programming.  There are a few different ways to
+use Streamz with a Tornado event loop.
+
+We give a few examples below that all do the same thing, but with different
+styles.  In each case we use the following toy functions:
+
+.. code-block:: python
+
+   from tornado import gen
+   import time
+
+   def increment(x):
+       """ A blocking increment function
+
+       Simulates a computational function that was not designed to work
+       asynchronously
+       """
+       time.sleep(0.1)
+       return x + 1
+
+   @gen.coroutine
+   def write(x):
+       """ A non-blocking write function
+
+       Simulates writing to a database asynchronously
+       """
+       yield gen.sleep(0.2)
+       print(x)
+
+
+Within the Event Loop
+---------------------
+
+You may have an application that runs strictly within an event loop.
+
+.. code-block:: python
+
+   from streamz import Stream
+   from tornado.ioloop import IOLoop
+
+   @gen.coroutine
+   def f():
+       source = Stream(asynchronous=True)  # tell the stream we're working asynchronously
+       source.map(increment).rate_limit(0.500).sink(write)
+
+       for x in range(10)
+           yield source.emit(x)
+
+   IOLoop.current().add_callback(f)
+   IOLoop.current().start()
+
+We call Stream with the ``asynchronous=True`` keyword, informing it that it
+should expect to operate within an event loop.  This ensures that calls to
+``emit`` return Tornado futures rather than block.  We wait on results using
+``yield``.
+
+.. code-block:: python
+
+   yield source.emit(x)  # waits until the pipeline is ready
+
+
+Event Loop on a Separate Thread
+-------------------------------
+
+Sometimes the event loop runs on a separate thread.  This is common when you
+want to support interactive workloads (the user needs their own thread for
+interaction) or when using Dask (next section).
+
+.. code-block:: python
+
+   from streamz import Stream
+   from tornado.ioloop import IOLoop
+   from threading import Thread
+   loop = IOLoop()
+   thread = Thread(target=loop.start, daemon=True)
+   thread.start()
+
+   source = Stream()
+   source.map(increment).rate_limit(0.500, loop=loop).sink(write)
+
+   for x in range(10):
+       source.emit(x)
+
+In this case we start the IOLoop running in a separate thread.  We had to tell
+``rate_limit`` which IOLoop to use explicitly by passing our IOLoop in the
+``loop=`` keyword.  We call ``source.emit`` without using ``yield``.  The emit
+call now blocks, waiting on a coroutine to finish within the IOLoop.
+
+All functions here happen on the IOLoop.  This is good for consistency, but can
+cause other concurrent applications to become unresponsive if your functions
+(like ``increment``) block for long periods of time.  You might address this by
+using Dask (see below) which will offload these computations onto separate
+threads or processes.
+
+
+Using Dask
+----------
+
+Dask_ is a parellel computing library that ses Tornado for concurrency and
+threads for computation.  The ``DaskStream`` object is a drop-in replacement
+for ``Stream`` (mostly).  We need to create a Dask client.  This will start a
+thread and IOLoop for us.
+
+.. code-block:: python
+
+   from dask.distributed import Client
+   client = Client(processes=False)  # starts thread pool, IOLoop in seaprate thread
+
+   from streamz.dask import DaskStream
+   source = DaskStream()  # connects to default client created above
+   source.map(increment).rate_limit(0.500).gather().sink(write)
+
+   for x in range(10):
+       source.emit(x)
+
+This operates very much like the synchronous case in terms of coding style (no
+``@gen.coroutine`` or ``yield``) but does computations on separate threads.
+This also provies parallelism and access to a dashboard at
+http://localhost:8787/status .
+
+
+Asynchronous Dask
+-----------------
+
+Dask can also operate within an event loop if preferred.  Here you can get the
+non-blocking operation within an event loop while also offloading computations
+to separate threads.
+
+.. code-block:: python
+
+   from streamz.dask import DaskStream
+   from dask.distributed import Client
+   from tornado import gen
+   from tornado.ioloop import IOLoop
+
+   @gen.coroutine
+   def f():
+       client = yield Client(processes=False, asynchronous=True)
+       source = DaskStream(asynchronous=True)
+       source.map(increment).rate_limit(0.500).gather().sink(write)
+
+       for x in range(10):
+           yield source.emit(x)
+
+   IOLoop.current().add_callback(f)
+   IOLoop.current().start()
+
+
+AsyncIO
+-------
+
+Tornado works well with AsyncIO (see `Tornado-AsyncIO bridge docs
+<http://www.tornadoweb.org/en/stable/asyncio.html>`_).  You will have to
+install the AsyncIO event loop as the Tornado event loop.
+
+.. code-block:: python
+
+   from streamz import Stream
+   from tornado.platform.asyncio import AsyncIOMainLoop
+   AsyncIOMainLoop().install()
+
+   @gen.coroutine
+   def f():
+       source = Stream(asynchronous=True)  # tell the stream we're working asynchronously
+       source.map(increment).rate_limit(0.500).sink(write)
+
+       for x in range(10):
+           yield source.emit(x)
+
+   f()
+
+   import asyncio
+   asyncio.get_event_loop().run_forever()
+
+
+
+.. _Tornado: http://www.tornadoweb.org/en/stable/
+.. _Dask: https://dask.pydata.org/en/latest/

--- a/examples/fib_thread.py
+++ b/examples/fib_thread.py
@@ -1,0 +1,27 @@
+from threading import Thread
+from streamz import Stream
+from tornado.ioloop import IOLoop
+
+loop = IOLoop()
+
+source = Stream()
+s = source.sliding_window(2).map(sum)
+L = s.sink_to_list()                    # store result in a list
+
+s.rate_limit(0.5, loop=loop).sink(source.emit)         # pipe output back to input
+s.rate_limit(1.0, loop=loop).sink(lambda x: print(L))  # print state of L every second
+
+source.emit(0)                          # seed with initial values
+source.emit(1)
+
+thread = Thread(target=loop.start, daemon=True)
+thread.start()
+
+
+# main thread is still free
+# so we can operate even while the event loop cycles
+import time
+time.sleep(1)
+source.emit(100)  # inject new data to fibonacci sequence
+
+time.sleep(3)  # wait more time before closing

--- a/examples/fib_tornado.py
+++ b/examples/fib_tornado.py
@@ -1,10 +1,8 @@
 from streamz import Stream
-import asyncio
-from tornado.platform.asyncio import AsyncIOMainLoop
-AsyncIOMainLoop().install()
+from tornado.ioloop import IOLoop
 
 
-source = Stream()
+source = Stream(asynchronous=True)
 s = source.sliding_window(2).map(sum)
 L = s.sink_to_list()                    # store result in a list
 
@@ -14,14 +12,4 @@ s.rate_limit(1.0).sink(lambda x: print(L))  # print state of L every second
 source.emit(0)                          # seed with initial values
 source.emit(1)
 
-
-def run_asyncio_loop():
-    loop = asyncio.get_event_loop()
-    try:
-        loop.run_forever()
-    except KeyboardInterrupt:
-        pass
-    finally:
-        loop.close()
-
-run_asyncio_loop()
+IOLoop.current().start()

--- a/streamz/collection.py
+++ b/streamz/collection.py
@@ -109,7 +109,7 @@ class Streaming(object):
                 IPython.display.clear_output(wait=True)
                 IPython.display.display(val)
 
-        s = self.stream.latest().rate_limit(0.5).map(update_cell)
+        s = self.stream.latest().rate_limit(0.5).gather().map(update_cell)
         _html_update_streams.add(s)
 
         self.output_ref = output_ref
@@ -267,7 +267,7 @@ def map_partitions(func, *args, **kwargs):
     streams = [arg for arg in args if isinstance(arg, Streaming)]
 
     if len(streams) > 1:
-        stream = core.zip(*[getattr(arg, 'stream', arg) for arg in args])
+        stream = type(streams[0].stream).zip(*[getattr(arg, 'stream', arg) for arg in args])
         stream = stream.map(apply_args, func, kwargs)
 
     else:

--- a/streamz/compatibility.py
+++ b/streamz/compatibility.py
@@ -1,6 +1,8 @@
 import sys
 
 if sys.version_info[0] == 2:
+    from thread import get_ident as get_thread_identity
     import __builtin__ as builtins
 else:
     import builtins
+    from threading import get_ident as get_thread_identity

--- a/streamz/core.py
+++ b/streamz/core.py
@@ -203,7 +203,7 @@ class Stream(object):
                 thread_state.asynchronous = True
             try:
                 result = self._emit(x)
-                return result
+                return gen.convert_yielded(result)
             finally:
                 thread_state.asynchronous = ts_async
         else:
@@ -414,7 +414,7 @@ class sink(Stream):
 
     def update(self, x, who=None):
         result = self.func(x)
-        if type(result) is gen.Future:
+        if gen.isawaitable(result):
             return result
         else:
             return []

--- a/streamz/core.py
+++ b/streamz/core.py
@@ -739,7 +739,7 @@ class zip(Stream):
             self.condition.notify_all()
             if self.literals:
                 self.pack_literals()
-            return self.emit(tup)
+            return self._emit(tup)
         elif len(L) > self.maxsize:
             return self.condition.wait()
 

--- a/streamz/core.py
+++ b/streamz/core.py
@@ -221,6 +221,13 @@ class Stream(object):
     def update(self, x, who=None):
         self.emit(x)
 
+    def gather(self):
+        """ This is a no-op for core streamz
+
+        This allows gather to be used in both dask and core streams
+        """
+        return self
+
     def connect(self, downstream):
         ''' Connect this stream to a downstream element.
 
@@ -435,7 +442,7 @@ class map(Stream):
     def update(self, x, who=None):
         result = self.func(x, *self.args, **self.kwargs)
 
-        return self.emit(result)
+        return self._emit(result)
 
 
 def _truthy(x):

--- a/streamz/dask.py
+++ b/streamz/dask.py
@@ -30,7 +30,7 @@ class map(DaskStream):
     def update(self, x, who=None):
         client = default_client()
         result = client.submit(self.func, x, *self.args, **self.kwargs)
-        return self.emit(result)
+        return self._emit(result)
 
 
 @DaskStream.register_api()
@@ -44,7 +44,7 @@ class scan(DaskStream):
     def update(self, x, who=None):
         if self.state is core.no_default:
             self.state = x
-            return self.emit(self.state)
+            return self._emit(self.state)
         else:
             client = default_client()
             result = client.submit(self.func, self.state, x)
@@ -54,7 +54,7 @@ class scan(DaskStream):
             else:
                 state = result
             self.state = state
-            return self.emit(result)
+            return self._emit(result)
 
 
 @DaskStream.register_api()
@@ -67,7 +67,7 @@ class scatter(DaskStream):
     def _update(self, x, who=None):
         client = default_client()
         future = yield client.scatter(x, asynchronous=True)
-        yield self.emit(future)
+        yield self._emit(future)
 
     def update(self, x, who=None):
         client = default_client()
@@ -82,7 +82,7 @@ class gather(core.Stream):
         client = default_client()
         result = yield client.gather(x, asynchronous=True)
         with set_thread_state(asynchronous=True):
-            result = self.emit(result)
+            result = self._emit(result)
         yield result
 
     def update(self, x, who=None):
@@ -91,10 +91,51 @@ class gather(core.Stream):
 
 
 @DaskStream.register_api()
+class buffer(DaskStream, core.buffer):
+    pass
+
+
+@DaskStream.register_api()
+class combine_latest(DaskStream, core.combine_latest):
+    pass
+
+
+@DaskStream.register_api()
+class delay(DaskStream, core.delay):
+    pass
+
+
+@DaskStream.register_api()
+class partition(DaskStream, core.partition):
+    pass
+
+
+@DaskStream.register_api()
+class rate_limit(DaskStream, core.rate_limit):
+    pass
+
+
+@DaskStream.register_api()
+class sliding_window(DaskStream, core.sliding_window):
+    pass
+
+
+@DaskStream.register_api()
+class timed_window(DaskStream, core.timed_window):
+    pass
+
+
+@DaskStream.register_api()
+class union(DaskStream, core.union):
+    pass
+
+
+@DaskStream.register_api()
 class zip(DaskStream, core.zip):
     pass
 
 
+"""
 @DaskStream.register_api()
 class buffer(DaskStream):
     def __init__(self, upstream, n, loop=None):
@@ -110,7 +151,7 @@ class buffer(DaskStream):
         while True:
             x = yield self.queue.get(asynchronous=True)
             with set_thread_state(asynchronous=True):
-                result = self.emit(x)
+                result = self._emit(x)
             yield result
 
     @gen.coroutine
@@ -120,3 +161,4 @@ class buffer(DaskStream):
 
     def update(self, x, who=None):
         return self.queue.put(x)
+"""

--- a/streamz/dataframe.py
+++ b/streamz/dataframe.py
@@ -530,7 +530,7 @@ class Random(StreamingDataFrame):
         self.interval = pd.Timedelta(interval).total_seconds() * 1000
 
         def trigger():
-            source.emit(None)
+            source._emit(None)
 
         self.pc = PeriodicCallback(trigger, self.interval)
         self.pc.start()
@@ -540,7 +540,7 @@ class Random(StreamingDataFrame):
         super(Random, self).__init__(stream, example)
 
     def _trigger(self):
-        self.source.emit(None)
+        self.source._emit(None)
 
     def __del__(self):
         self.pc.stop()

--- a/streamz/dataframe.py
+++ b/streamz/dataframe.py
@@ -85,10 +85,17 @@ class StreamingFrame(Streaming):
 
         result = show(fig, notebook_handle=True)
 
+        from tornado.ioloop import IOLoop
+        loop = IOLoop.current()
+
         def push_data(df):
-            print(df.reset_index())
-            cds.stream(df.reset_index(), backlog)
-            push_notebook(handle=result)
+            df = df.reset_index()
+            d = {c: df[c] for c in df.columns}
+
+            def _():
+                cds.stream(d, backlog)
+                push_notebook(handle=result)
+            loop.add_callback(_)
 
         return {'figure': fig, 'cds': cds, 'stream': sdf.stream.gather().map(push_data)}
 

--- a/streamz/sources.py
+++ b/streamz/sources.py
@@ -12,7 +12,7 @@ def PeriodicCallback(callback, callback_time, **kwargs):
 
     def _():
         result = callback()
-        source.emit(result)
+        source._emit(result)
 
     pc = tornado.ioloop.PeriodicCallback(_, callback_time, **kwargs)
     pc.start()
@@ -68,7 +68,7 @@ class TextFile(Source):
         while True:
             line = self.file.readline()
             if line:
-                last = self.emit(line)  # TODO: we should yield on emit
+                last = self._emit(line)  # TODO: we should yield on emit
             else:
                 if self.poll_interval:
                     yield gen.sleep(self.poll_interval)
@@ -112,5 +112,5 @@ class filenames(Source):
             new = filenames - self.seen
             for fn in sorted(new):
                 self.seen.add(fn)
-                yield self.emit(fn)
+                yield self._emit(fn)
             yield gen.sleep(self.poll_interval)  # TODO: remove poll if delayed

--- a/streamz/tests/py3_test_core.py
+++ b/streamz/tests/py3_test_core.py
@@ -1,0 +1,27 @@
+from time import time
+from distributed.utils_test import loop, inc  # noqa
+from tornado import gen
+
+from streamz import Stream
+
+
+def test_await_syntax(loop):  # noqa
+    L = []
+
+    async def write(x):
+        await gen.sleep(0.1)
+        L.append(x)
+
+    async def f():
+        source = Stream(asynchronous=True)
+        source.map(inc).buffer(3).sink(write)
+
+        start = time()
+        for x in range(6):
+            await source.emit(x)
+        stop = time()
+
+        assert 0.2 < stop - start < 0.4
+        assert 2 <= len(L) <= 4
+
+    loop.run_sync(f)

--- a/streamz/tests/py3_test_core.py
+++ b/streamz/tests/py3_test_core.py
@@ -1,3 +1,4 @@
+# flake8: noqa
 from time import time
 from distributed.utils_test import loop, inc  # noqa
 from tornado import gen

--- a/streamz/tests/test_core.py
+++ b/streamz/tests/test_core.py
@@ -1,11 +1,12 @@
 from datetime import timedelta
+from functools import partial
 import itertools
 import json
 import operator
 from operator import add
 import os
 from time import time, sleep
-from functools import partial
+import sys
 
 import pytest
 
@@ -910,3 +911,7 @@ def test_separate_thread_with_time(loop, thread):
 
     assert stop - start > 0.1
     assert L == [2]
+
+
+if sys.version_info >= (3, 5):
+    from streamz.tests.py3_test_core import *  # noqa

--- a/streamz/utils.py
+++ b/streamz/utils.py
@@ -1,5 +1,3 @@
-
-
 _method_cache = {}
 
 


### PR DESCRIPTION
Three main changes:

1.  Support synchronous action in streams.  This allows operations like emit to operate sensibly when called from threads that are not the main event loop.  They will block in the same way that they would wait previously when called with yield in a coroutine
2.  Connect all of the relevant operations to Dask.  Now that sync/async workflow works nicely we can simplify much of the DaskStream connection code
3.  Support `await emit` in the common case

For downstream code this means that we need to be a bit more aware about creating streams in fully asynchronous mode.  I've created a doc page that goes through some of the nuance here

I expect that this may break existing code.