### PR TITLE
Add missing .sink(print) in docs

### DIFF
--- a/docs/source/core.rst
+++ b/docs/source/core.rst
@@ -104,7 +104,7 @@ number of distinct elements that we have seen so far.
        return state, len(state)
 
     source = Stream()
-    source.accumulate(num_distinct, returns_state=True, start=set())
+    source.accumulate(num_distinct, returns_state=True, start=set()).sink(print)
 
     >>> source.emit('cat')
     1


### PR DESCRIPTION
Looks like the `num_distinct` example in the ["Accumulating State"](http://streamz.readthedocs.io/en/latest/core.html#accumulating-state) section is missing a `.sink(print)` so that the number of distinct elements actually gets printed.