### PR TITLE
 Manage event loops in separate threads

### DIFF
--- a/docs/source/async.rst
+++ b/docs/source/async.rst
@@ -80,14 +80,9 @@ interaction) or when using Dask (next section).
 .. code-block:: python
 
    from streamz import Stream
-   from tornado.ioloop import IOLoop
-   from threading import Thread
-   loop = IOLoop()
-   thread = Thread(target=loop.start, daemon=True)
-   thread.start()
 
-   source = Stream()
-   source.map(increment).rate_limit(0.500, loop=loop).sink(write)
+   source = Stream(ensure_io_loop=True)  # starts IOLoop in separate thread
+   source.map(increment).rate_limit('500ms').sink(write)
 
    for x in range(10):
        source.emit(x)

--- a/docs/source/async.rst
+++ b/docs/source/async.rst
@@ -121,8 +121,8 @@ Using Dask
 
 Dask_ is a parellel computing library that uses Tornado for concurrency and
 threads for computation.  The ``DaskStream`` object is a drop-in replacement
-for ``Stream`` (mostly).  We need to create a Dask client.  This will start a
-thread and IOLoop for us.
+for ``Stream`` (mostly). Typically we create a Dask client, and then
+``scatter`` a local Stream to become a DaskStream.
 
 .. code-block:: python
 
@@ -131,9 +131,9 @@ thread and IOLoop for us.
 
    from streamz import Stream
    source = Stream()
-   (source.scatter()       # move local data out to the cluster
-          .map(increment)  # apply a function remotely
-          .buffer(100)     # allow one hundred futures to stay on the cluster
+   (source.scatter()       # scatter local elements to cluster, creating a DaskStream
+          .map(increment)  # map a function remotely
+          .buffer(5)       # allow five futures to stay on the cluster at any time
           .gather()        # bring results back to local process
           .sink(write))    # call write locally
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -67,7 +67,6 @@ However this quickly become cumbersome, especially when building complex
 pipelines.
 
 
-
 Related Work
 ------------
 

--- a/examples/fib_thread.py
+++ b/examples/fib_thread.py
@@ -1,27 +1,12 @@
-from threading import Thread
 from streamz import Stream
 from tornado.ioloop import IOLoop
-
-loop = IOLoop()
 
 source = Stream()
 s = source.sliding_window(2).map(sum)
 L = s.sink_to_list()                    # store result in a list
 
-s.rate_limit(0.5, loop=loop).sink(source.emit)         # pipe output back to input
-s.rate_limit(1.0, loop=loop).sink(lambda x: print(L))  # print state of L every second
+s.rate_limit('500ms').sink(source.emit)      # pipe output back to input
+s.rate_limit('1s').sink(lambda x: print(L))  # print state of L every second
 
 source.emit(0)                          # seed with initial values
 source.emit(1)
-
-thread = Thread(target=loop.start, daemon=True)
-thread.start()
-
-
-# main thread is still free
-# so we can operate even while the event loop cycles
-import time
-time.sleep(1)
-source.emit(100)  # inject new data to fibonacci sequence
-
-time.sleep(3)  # wait more time before closing

--- a/examples/fib_tornado.py
+++ b/examples/fib_tornado.py
@@ -6,8 +6,8 @@ source = Stream(asynchronous=True)
 s = source.sliding_window(2).map(sum)
 L = s.sink_to_list()                    # store result in a list
 
-s.rate_limit(0.5).sink(source.emit)         # pipe output back to input
-s.rate_limit(1.0).sink(lambda x: print(L))  # print state of L every second
+s.rate_limit('500ms').sink(source.emit)         # pipe output back to input
+s.rate_limit('1s').sink(lambda x: print(L))  # print state of L every second
 
 source.emit(0)                          # seed with initial values
 source.emit(1)

--- a/streamz/core.py
+++ b/streamz/core.py
@@ -31,6 +31,23 @@ thread_state = threading.local()
 logger = logging.getLogger(__name__)
 
 
+_io_loops = []
+
+
+def get_io_loop(asynchronous=None):
+    if asynchronous:
+        return IOLoop.current()
+
+    if not _io_loops:
+        loop = IOLoop()
+        thread = threading.Thread(target=loop.start)
+        thread.daemon = True
+        thread.start()
+        _io_loops.append(loop)
+
+    return _io_loops[-1]
+
+
 def identity(x):
     return x
 
@@ -44,6 +61,16 @@ class Stream(object):
     subscribe to it.  Downstream Stream objects may connect at any point of a
     Stream graph to get a full view of the data coming off of that point to do
     with as they will.
+
+    Parameters
+    ----------
+    asynchronous: boolean or None
+        Whether or not this stream will be used in asynchronous functions or
+        normal Python functions.  Leave as None if you don't know.
+    ensure_io_loop: boolean
+        Ensure that some IOLoop will be created.  If asynchronous is None or
+        False then this will be in a separate thread, otherwise it will be
+        IOLoop.current
 
     Examples
     --------
@@ -75,35 +102,45 @@ class Stream(object):
     str_list = ['func', 'predicate', 'n', 'interval']
 
     def __init__(self, upstream=None, upstreams=None, stream_name=None,
-                 loop=None, asynchronous=False):
-        self.asynchronous = asynchronous
+                 loop=None, asynchronous=None, ensure_io_loop=False):
         self.downstreams = OrderedWeakrefSet()
         if upstreams is not None:
             self.upstreams = upstreams
         else:
             self.upstreams = [upstream]
-        if loop is None:
-            for upstream in self.upstreams:
-                if upstream and upstream.loop:
-                    loop = upstream.loop
-                    break
-        self.loop = loop
+
+        self._set_asynchronous(asynchronous)
+        self._set_loop(loop)
+        if ensure_io_loop and not self.loop:
+            self._set_asynchronous(False)
+        if self.loop is None and self.asynchronous is not None:
+            self._set_loop(get_io_loop(self.asynchronous))
+
         for upstream in self.upstreams:
             if upstream:
                 upstream.downstreams.add(self)
+
         self.name = stream_name
-        if loop:
+
+    def _set_loop(self, loop):
+        self.loop = None
+        if loop is not None:
+            self._inform_loop(loop)
+        else:
             for upstream in self.upstreams:
-                if upstream:
-                    upstream._inform_loop(loop)
+                if upstream and upstream.loop:
+                    self.loop = upstream.loop
+                    inform = False
+                    break
 
     def _inform_loop(self, loop):
         """
         Percolate information about an event loop to the rest of the stream
         """
-        if self.loop is loop:
-            return
-        elif self.loop is None:
+        if self.loop is not None:
+            if self.loop is not loop:
+                raise ValueError("Two different event loops active")
+        else:
             self.loop = loop
             for upstream in self.upstreams:
                 if upstream:
@@ -111,8 +148,32 @@ class Stream(object):
             for downstream in self.downstreams:
                 if downstream:
                     downstream._inform_loop(loop)
+
+    def _set_asynchronous(self, asynchronous):
+        self.asynchronous = None
+        if asynchronous is not None:
+            self._inform_asynchronous(asynchronous)
         else:
-            raise ValueError("Two different event loops active")
+            for upstream in self.upstreams:
+                if upstream and upstream.asynchronous:
+                    self.asynchronous = upstream.asynchronous
+                    break
+
+    def _inform_asynchronous(self, asynchronous):
+        """
+        Percolate information about an event loop to the rest of the stream
+        """
+        if self.asynchronous is not None:
+            if self.asynchronous is not asynchronous:
+                raise ValueError("Stream has both asynchronous and synchronous elements")
+        else:
+            self.asynchronous = asynchronous
+            for upstream in self.upstreams:
+                if upstream:
+                    upstream._inform_asynchronous(asynchronous)
+            for downstream in self.downstreams:
+                if downstream:
+                    downstream._inform_asynchronous(asynchronous)
 
     @classmethod
     def register_api(cls, modifier=identity):
@@ -710,13 +771,12 @@ class timed_window(Stream):
     """
     _graphviz_shape = 'octagon'
 
-    def __init__(self, upstream, interval, loop=None, **kwargs):
-        loop = loop or upstream.loop or IOLoop.current()
+    def __init__(self, upstream, interval, **kwargs):
         self.interval = convert_interval(interval)
         self.buffer = []
         self.last = gen.moment
 
-        Stream.__init__(self, upstream, loop=loop, **kwargs)
+        Stream.__init__(self, upstream, ensure_io_loop=True, **kwargs)
 
         self.loop.add_callback(self.cb)
 
@@ -738,12 +798,11 @@ class delay(Stream):
     """ Add a time delay to results """
     _graphviz_shape = 'octagon'
 
-    def __init__(self, upstream, interval, loop=None, **kwargs):
-        loop = loop or upstream.loop or IOLoop.current()
+    def __init__(self, upstream, interval, **kwargs):
         self.interval = convert_interval(interval)
         self.queue = Queue()
 
-        Stream.__init__(self, upstream, loop=loop, **kwargs)
+        Stream.__init__(self, upstream, ensure_io_loop=True, **kwargs)
 
         self.loop.add_callback(self.cb)
 
@@ -801,11 +860,10 @@ class buffer(Stream):
     """
     _graphviz_shape = 'diamond'
 
-    def __init__(self, upstream, n, loop=None, **kwargs):
-        loop = loop or upstream.loop or IOLoop.current()
+    def __init__(self, upstream, n, **kwargs):
         self.queue = Queue(maxsize=n)
 
-        Stream.__init__(self, upstream, loop=loop, **kwargs)
+        Stream.__init__(self, upstream, ensure_io_loop=True, **kwargs)
 
         self.loop.add_callback(self.cb)
 
@@ -1139,12 +1197,11 @@ class latest(Stream):
     """
     _graphviz_shape = 'octagon'
 
-    def __init__(self, upstream, loop=None):
-        loop = loop or upstream.loop or IOLoop.current()
+    def __init__(self, upstream, **kwargs):
         self.condition = Condition()
         self.next = []
 
-        Stream.__init__(self, upstream, loop=loop)
+        Stream.__init__(self, upstream, ensure_io_loop=True, **kwargs)
 
         self.loop.add_callback(self.cb)
 

--- a/streamz/core.py
+++ b/streamz/core.py
@@ -67,6 +67,8 @@ class Stream(object):
     asynchronous: boolean or None
         Whether or not this stream will be used in asynchronous functions or
         normal Python functions.  Leave as None if you don't know.
+        True will cause operations like emit to return awaitable Futures
+        False will use an Event loop in another thread (starts it if necessary)
     ensure_io_loop: boolean
         Ensure that some IOLoop will be created.  If asynchronous is None or
         False then this will be in a separate thread, otherwise it will be
@@ -838,7 +840,7 @@ class rate_limit(Stream):
         self.interval = convert_interval(interval)
         self.next = 0
 
-        Stream.__init__(self, upstream, **kwargs)
+        Stream.__init__(self, upstream, ensure_io_loop=True, **kwargs)
 
     @gen.coroutine
     def update(self, x, who=None):

--- a/streamz/sources.py
+++ b/streamz/sources.py
@@ -2,7 +2,6 @@ from glob import glob
 import os
 
 import tornado.ioloop
-from tornado.ioloop import IOLoop
 from tornado import gen
 
 from .core import Stream
@@ -147,7 +146,6 @@ class from_kafka(Source):
     """
     def __init__(self, topics, consumer_params, poll_interval=0.1):
         import confluent_kafka as ck
-        IOLoop.current().add_callback(self.poll_kafka)
         self.cpars = consumer_params
         self.consumer = ck.Consumer(consumer_params)
         self.consumer.subscribe(topics)
@@ -155,6 +153,7 @@ class from_kafka(Source):
         self.sleep = poll_interval
 
         super(from_kafka, self).__init__(ensure_io_loop=True)
+        self.loop.add_callback(self.poll_kafka)
 
     @gen.coroutine
     def poll_kafka(self):

--- a/streamz/sources.py
+++ b/streamz/sources.py
@@ -8,8 +8,8 @@ from tornado import gen
 from .core import Stream
 
 
-def PeriodicCallback(callback, callback_time, **kwargs):
-    source = Stream()
+def PeriodicCallback(callback, callback_time, asynchronous=False, **kwargs):
+    source = Stream(asynchronous=asynchronous)
 
     def _():
         result = callback()

--- a/streamz/sources.py
+++ b/streamz/sources.py
@@ -63,7 +63,7 @@ class from_textfile(Source):
         self.file = f
 
         self.poll_interval = poll_interval
-        super(from_textfile, self).__init__(**kwargs)
+        super(from_textfile, self).__init__(ensure_io_loop=True, **kwargs)
 
     @gen.coroutine
     def start(self):
@@ -104,7 +104,7 @@ class filenames(Source):
         self.seen = set()
         self.poll_interval = poll_interval
 
-        super(filenames, self).__init__()
+        super(filenames, self).__init__(ensure_io_loop=True)
 
     @gen.coroutine
     def start(self):
@@ -154,7 +154,7 @@ class from_kafka(Source):
         self.topics = topics
         self.sleep = poll_interval
 
-        super(from_kafka, self).__init__()
+        super(from_kafka, self).__init__(ensure_io_loop=True)
 
     @gen.coroutine
     def poll_kafka(self):

--- a/streamz/tests/test_core.py
+++ b/streamz/tests/test_core.py
@@ -40,6 +40,11 @@ def test_basic():
     assert Lb == [0, 2, 4, 6]
 
 
+def test_no_output():
+    source = Stream()
+    assert source.emit(1) is None
+
+
 def test_scan():
     source = Stream()
 

--- a/streamz/tests/test_core.py
+++ b/streamz/tests/test_core.py
@@ -16,9 +16,10 @@ from tornado.ioloop import IOLoop
 
 import streamz as sz
 
-from ..core import Stream
+from streamz import Stream
 from streamz.sources import sink_to_file, PeriodicCallback
-from streamz.utils_test import inc, double, gen_test, tmpfile, captured_logger
+from streamz.utils_test import (inc, double, gen_test, tmpfile, captured_logger,
+        clean)
 from distributed.utils_test import loop
 
 
@@ -194,7 +195,7 @@ def test_timed_window():
     assert not L[-1]
 
 
-def test_timed_window_timedelta():
+def test_timed_window_timedelta(clean):
     pytest.importorskip('pandas')
     source = Stream(asynchronous=True)
     a = source.timed_window('10ms')
@@ -257,7 +258,7 @@ def test_sink_with_args_and_kwargs():
 @gen_test()
 def test_counter():
     counter = itertools.count()
-    source = PeriodicCallback(lambda: next(counter), 0.001)
+    source = PeriodicCallback(lambda: next(counter), 0.001, asynchronous=True)
     L = source.sink_to_list()
     yield gen.sleep(0.05)
 
@@ -597,7 +598,7 @@ def test_filter_str():
     assert str(s) == '<filter: iseven>'
 
 
-def test_timed_window_str():
+def test_timed_window_str(clean):
     source = Stream()
     s = source.timed_window(.05)
     assert str(s) == '<timed_window: 0.05>'
@@ -736,7 +737,8 @@ def test_from_file():
             f.write('{"x": 3, "y": 2}\n')
             f.flush()
 
-            source = Stream.from_textfile(fn, poll_interval=0.010)
+            source = Stream.from_textfile(fn, poll_interval=0.010,
+                                          asynchronous=True)
             L = source.map(json.loads).pluck('x').sink_to_list()
 
             assert L == []
@@ -764,7 +766,7 @@ def test_filenames():
         with open(os.path.join(fn, 'b'), 'w') as f:
             pass
 
-        source = Stream.filenames(fn)
+        source = Stream.filenames(fn, asynchronous=True)
         L = source.sink_to_list()
         source.start()
 
@@ -850,7 +852,7 @@ def test_destroy():
     assert L == [2]
 
 
-def dont_test_stream_kwargs():
+def dont_test_stream_kwargs(clean):
     ''' Test the good and bad kwargs for the stream
         Currently just stream_name
     '''
@@ -923,11 +925,11 @@ def thread(loop):
     return thread
 
 
-def test_percolate_loop_information(loop, thread):
+def test_percolate_loop_information(clean):
     source = Stream()
     assert not source.loop
     s = source.timed_window(0.5)
-    assert source.loop is IOLoop.current()
+    assert source.loop is s.loop
 
 
 def test_separate_thread_without_time(loop, thread):
@@ -940,7 +942,7 @@ def test_separate_thread_without_time(loop, thread):
         assert L[-1] == i + 1
 
 
-def test_separate_thread_with_time(loop, thread):
+def test_separate_thread_with_time(clean):
     L = []
 
     @gen.coroutine
@@ -948,7 +950,7 @@ def test_separate_thread_with_time(loop, thread):
         yield gen.sleep(0.1)
         L.append(x)
 
-    source = Stream(loop=loop)
+    source = Stream(asynchronous=False)
     source.map(inc).sink(slow_write)
 
     start = time()
@@ -990,7 +992,7 @@ def test_execution_order():
 
 @gen_test()
 def test_map_errors_log():
-    a = Stream()
+    a = Stream(asynchronous=True)
     b = a.delay(0.001).map(lambda x: 1 / x)
     with captured_logger('streamz') as logger:
         a._emit(0)
@@ -1009,7 +1011,7 @@ def test_map_errors_raises():
 
 @gen_test()
 def test_accumulate_errors_log():
-    a = Stream()
+    a = Stream(asynchronous=True)
     b = a.delay(0.001).accumulate(lambda x, y: x / y)
     with captured_logger('streamz') as logger:
         a._emit(1)
@@ -1026,6 +1028,34 @@ def test_accumulate_errors_raises():
     with pytest.raises(ZeroDivisionError):
         a.emit(1)
         a.emit(0)
+
+
+@gen_test()
+def test_sync_in_event_loop():
+    a = Stream()
+    assert not a.asynchronous
+    L = a.timed_window(0.01).sink_to_list()
+    sleep(0.05)
+    assert L
+    assert a.loop
+    assert a.loop is not IOLoop.current()
+
+
+def test_share_common_ioloop(clean):
+    a = Stream()
+    b = Stream()
+    c = a.timed_window(0.01).combine_latest(b)
+    assert a.loop
+    assert a.loop is b.loop
+    assert a.loop is c.loop
+
+
+def test_share_common_ioloop(clean):
+    a = Stream()
+    b = Stream()
+    aa = a.timed_window(0.01)
+    bb = b.timed_window(0.01)
+    assert aa.loop is bb.loop
 
 
 if sys.version_info >= (3, 5):

--- a/streamz/utils_test.py
+++ b/streamz/utils_test.py
@@ -115,4 +115,4 @@ def clean():
     for loop in _io_loops:
         loop.add_callback(loop.stop)
 
-    _io_loops.clear()
+    del _io_loops[:]

--- a/streamz/utils_test.py
+++ b/streamz/utils_test.py
@@ -5,8 +5,11 @@ import six
 import shutil
 import tempfile
 
+import pytest
 from tornado import gen
 from tornado.ioloop import IOLoop
+
+from .core import _io_loops
 
 
 @contextmanager
@@ -105,3 +108,11 @@ def captured_logger(logger, level=logging.INFO, propagate=None):
         logger.setLevel(orig_level)
         if propagate is not None:
             logger.propagate = orig_propagate
+
+
+@pytest.fixture
+def clean():
+    for loop in _io_loops:
+        loop.add_callback(loop.stop)
+
+    _io_loops.clear()


### PR DESCRIPTION
This changes the default to create new event loops in separate threads
rather than use IOLoop.current() if asynchronous=True is not set
explicitly.

This is not perfect, but I think it's better.
