### PR TITLE
Added the to_kafka stream

### DIFF
--- a/streamz/core.py
+++ b/streamz/core.py
@@ -1274,8 +1274,6 @@ class to_kafka(Stream):
 
         Stream.__init__(self, upstream, ensure_io_loop=True, **kwargs)
 
-        _global_sinks.add(self)
-
     def update(self, x, who=None):
         self.producer.poll(0)
         self.producer.produce(self.topic, str(x).encode('utf-8'), callback=self.cb)

--- a/streamz/core.py
+++ b/streamz/core.py
@@ -1254,11 +1254,13 @@ class to_kafka(Stream):
 
     Examples
     --------
+    >>> ARGS = {'bootstrap.servers': 'localhost:9092'}
     >>> source = Stream()
-    >>> source.map(lambda x: x + 1).to_kafka('test', {'bootstrap.servers': 'localhost'}).sink(
-    ...     lambda x: print(x[1].topic(), x[1].partition()))
+    >>> kafka = source.map(lambda x: x + 1).to_kafka('test', ARGS)
+    >>> kafka.sink(lambda x: print(x[1].topic(), x[1].partition()))
     >>> for i in range(3):
     ...     source.emit(i)
+    >>> kafka.flush()
     test 0
     test 0
     test 0

--- a/streamz/core.py
+++ b/streamz/core.py
@@ -17,10 +17,6 @@ from tornado.locks import Condition
 from tornado.ioloop import IOLoop
 from tornado.queues import Queue
 try:
-    import confluent_kafka as ck
-except ImportError:
-    ck = None  # confluent_kafka is only required when interacting with Kafka
-try:
     from tornado.ioloop import PollIOLoop
 except ImportError:
     PollIOLoop = None  # dropped in tornado 6.0
@@ -1268,6 +1264,8 @@ class to_kafka(Stream):
     test 0
     """
     def __init__(self, upstream, topic, producer_config, **kwargs):
+        import confluent_kafka as ck
+
         self.topic = topic
         self.producer = ck.Producer(producer_config)
         atexit.register(self.producer.flush)

--- a/streamz/tests/test_core.py
+++ b/streamz/tests/test_core.py
@@ -942,7 +942,7 @@ def dont_test_stream_kwargs(clean):
 
 
 @pytest.fixture
-def thread(loop):
+def thread(loop):   # noqa: E811
     from threading import Thread, Event
     thread = Thread(target=loop.start)
     thread.daemon = True

--- a/streamz/tests/test_core.py
+++ b/streamz/tests/test_core.py
@@ -943,7 +943,7 @@ def dont_test_stream_kwargs(clean):  # noqa: F811
 
 
 @pytest.fixture
-def thread(loop):  # noqa: E811
+def thread(loop):  # noqa: F811
     from threading import Thread, Event
     thread = Thread(target=loop.start)
     thread.daemon = True

--- a/streamz/tests/test_dask.py
+++ b/streamz/tests/test_dask.py
@@ -73,7 +73,7 @@ def test_zip(c, s, a, b):
     assert L == [(1, 'a'), (2, 'b')]
 
 
-@pytest.mark.slow  
+@pytest.mark.slow
 def test_sync(loop):  # noqa: F811
     with cluster() as (s, [a, b]):
         with Client(s['address'], loop=loop) as client:  # noqa: F841
@@ -91,7 +91,7 @@ def test_sync(loop):  # noqa: F811
 
 
 @pytest.mark.slow
-def test_sync_2(loop):  # noqa: E811
+def test_sync_2(loop):  # noqa: F811
     with cluster() as (s, [a, b]):
         with Client(s['address'], loop=loop):  # noqa: F841
             source = Stream()
@@ -132,7 +132,7 @@ def test_buffer(c, s, a, b):
 
 
 @pytest.mark.slow
-def test_buffer_sync(loop):  # noqa: E811
+def test_buffer_sync(loop):  # noqa: F811
     with cluster() as (s, [a, b]):
         with Client(s['address'], loop=loop) as c:  # noqa: F841
             source = Stream()
@@ -155,9 +155,9 @@ def test_buffer_sync(loop):  # noqa: E811
             assert L == list(map(inc, range(10)))
 
 
-@pytest.mark.xfail(reason='')  # noqa: F811
+@pytest.mark.xfail(reason='')
 @pytest.mark.slow
-def test_stream_shares_client_loop(loop):  # noqa: E811
+def test_stream_shares_client_loop(loop):  # noqa: F811
     with cluster() as (s, [a, b]):
         with Client(s['address'], loop=loop) as client:  # noqa: F841
             source = Stream()

--- a/streamz/tests/test_dask.py
+++ b/streamz/tests/test_dask.py
@@ -74,7 +74,7 @@ def test_zip(c, s, a, b):
 
 
 @pytest.mark.slow
-def test_sync(loop):
+def test_sync(loop):  # noqa: E811
     with cluster() as (s, [a, b]):
         with Client(s['address'], loop=loop) as client:  # flake8: noqa
             source = Stream()
@@ -91,7 +91,7 @@ def test_sync(loop):
 
 
 @pytest.mark.slow
-def test_sync_2(loop):
+def test_sync_2(loop):  # noqa: E811
     with cluster() as (s, [a, b]):
         with Client(s['address'], loop=loop):  # flake8: noqa
             source = Stream()
@@ -132,7 +132,7 @@ def test_buffer(c, s, a, b):
 
 
 @pytest.mark.slow
-def test_buffer_sync(loop):
+def test_buffer_sync(loop):  # noqa: E811
     with cluster() as (s, [a, b]):
         with Client(s['address'], loop=loop) as c:  # flake8: noqa
             source = Stream()
@@ -158,7 +158,7 @@ def test_buffer_sync(loop):
 
 @pytest.mark.xfail(reason='')
 @pytest.mark.slow
-def test_stream_shares_client_loop(loop):
+def test_stream_shares_client_loop(loop):  # noqa: E811
     with cluster() as (s, [a, b]):
         with Client(s['address'], loop=loop) as client:  # flake8: noqa
             source = Stream()

--- a/streamz/tests/test_kafka.py
+++ b/streamz/tests/test_kafka.py
@@ -145,7 +145,7 @@ def test_from_kafka():
 
 
 @gen_test(timeout=60)
-async def test_to_kafka():
+def test_to_kafka():
     ARGS = {'bootstrap.servers': 'localhost:9092'}
     with kafka_service():
         source = Stream()

--- a/streamz/tests/test_kafka.py
+++ b/streamz/tests/test_kafka.py
@@ -122,6 +122,7 @@ def test_from_kafka():
         stream = Stream.from_kafka([TOPIC], ARGS, asynchronous=True)
         out = stream.sink_to_list()
         stream.start()
+        sleep(5)
         for i in range(10):
             kafka.produce(TOPIC, b'value-%d' % i)
         kafka.flush()
@@ -173,6 +174,7 @@ def test_from_kafka_thread():
         stream = Stream.from_kafka([TOPIC], ARGS)
         out = stream.sink_to_list()
         stream.start()
+        sleep(2)
         for i in range(10):
             kafka.produce(TOPIC, b'value-%d' % i)
         kafka.flush()
@@ -202,6 +204,7 @@ def test_kafka_batch():
         stream = Stream.from_kafka_batched(TOPIC, ARGS)
         out = stream.sink_to_list()
         stream.start()
+        sleep(2)
         for i in range(10):
             kafka.produce(TOPIC, b'value-%d' % i)
         kafka.flush()
@@ -219,6 +222,7 @@ def test_kafka_dask_batch(c, s, w1, w2):
         stream = Stream.from_kafka_batched(TOPIC, ARGS, asynchronous=True,
                                            dask=True)
         stream.start()
+        sleep(2)
         assert isinstance(stream, DaskStream)
         out = stream.gather().sink_to_list()
         for i in range(10):

--- a/streamz/tests/test_kafka.py
+++ b/streamz/tests/test_kafka.py
@@ -186,7 +186,7 @@ def test_kafka_batch():
         kafka.flush()
         # out may still be empty or first item of out may be []
         wait_for(lambda: any(out) and out[-1][-1] == b'value-9', 10, period=0.2)
-        stream.stopped = True
+        stream.upstream.stopped = True
 
 
 @gen_cluster(client=True, timeout=60)
@@ -209,4 +209,4 @@ def test_kafka_dask_batch(c, s, w1, w2):
             timeout -= 0.2
             assert timeout > 0, "Timeout"
         assert out[0][-1] == b'value-9'
-        stream.stopped = True
+        stream.upstream.stopped = True

--- a/streamz/tests/test_kafka.py
+++ b/streamz/tests/test_kafka.py
@@ -153,8 +153,7 @@ def test_to_kafka():
         out = kafka.sink_to_list()
 
         for i in range(10):
-            await source.emit(b'value-%d' % i, asynchronous=True)
-        print(out)
+            yield source.emit(b'value-%d' % i, asynchronous=True)
 
         source.emit('final message')
         kafka.flush()


### PR DESCRIPTION
I have added the to_kafka class.

The options were to either: 

1. Call the `.flush()` method after each `.produce(...)` call. This will seriously hurt performance as messages will be sent serially.
2. Use `atexit` to call flush at the end.  This requires the use of `atexit`, of which I'm unsure of any impact. It also means that the result of the `.emit(...)` call by the client does not yield an immediate call to the downstream. Note that the Confluent library will flush when the batch size reaches a threshold.  This is the method that is implemented here.