### PR TITLE
Fixed FutureWarning when creating DatetimeIndex

### DIFF
--- a/streamz/dataframe/core.py
+++ b/streamz/dataframe/core.py
@@ -706,9 +706,8 @@ class WindowedGroupBy(GroupBy):
 
 def _random_df(tup):
     last, now, freq = tup
-    index = pd.DatetimeIndex(start=(last + freq.total_seconds()) * 1e9,
-                             end=now * 1e9,
-                             freq=freq)
+    index = pd.date_range(start=(last + freq.total_seconds()) * 1e9,
+                          end=now * 1e9, freq=freq)
 
     df = pd.DataFrame({'x': np.random.random(len(index)),
                        'y': np.random.poisson(size=len(index)),


### PR DESCRIPTION
Using future pandas (>0.24.0) creating a DatetimeIndex using start and endpoints will no longer be supported, which means that the Random streaming dataframe very noisily issues these FutureWarnings:

```
/Users/philippjfr/miniconda/envs/anacondaviz/lib/python3.6/site-packages/streamz/dataframe/core.py:711: FutureWarning: Creating a DatetimeIndex by passing range endpoints is deprecated.  Use `pandas.date_range` instead.
  freq=freq)
```