### PR TITLE
Kafka fixes

### DIFF
--- a/streamz/core.py
+++ b/streamz/core.py
@@ -1268,7 +1268,7 @@ class to_kafka(Stream):
 
         Stream.__init__(self, upstream, ensure_io_loop=True, **kwargs)
         self.stopped = False
-        self.polltime = 0.5
+        self.polltime = 0.2
         self.loop.add_callback(self.poll)
         self.futures = []
 
@@ -1295,7 +1295,7 @@ class to_kafka(Stream):
                     self.producer.produce(self.topic, x, callback=self.cb)
                     return
                 except BufferError:
-                    yield gen.sleep(0.1)
+                    yield gen.sleep(self.polltime)
                 except Exception as e:
                     future.set_exception(e)
                     return

--- a/streamz/core.py
+++ b/streamz/core.py
@@ -1274,8 +1274,6 @@ class to_kafka(Stream):
 
         Stream.__init__(self, upstream, ensure_io_loop=True, **kwargs)
 
-        _global_sinks.add(self)
-
     def update(self, x, who=None):
         self.producer.poll(0)
         self.producer.produce(self.topic, str(x).encode('utf-8'), callback=self.cb)

--- a/streamz/core.py
+++ b/streamz/core.py
@@ -1254,11 +1254,13 @@ class to_kafka(Stream):
 
     Examples
     --------
+    >>> ARGS = {'bootstrap.servers': 'localhost:9092'}
     >>> source = Stream()
-    >>> source.map(lambda x: x + 1).to_kafka('test', {'bootstrap.servers': 'localhost'}).sink(
-    ...     lambda x: print(x[1].topic(), x[1].partition()))
+    >>> kafka = source.map(lambda x: x + 1).to_kafka('test', ARGS)
+    >>> kafka.sink(lambda x: print(x[1].topic(), x[1].partition()))
     >>> for i in range(3):
     ...     source.emit(i)
+    >>> kafka.flush()
     test 0
     test 0
     test 0

--- a/streamz/core.py
+++ b/streamz/core.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
-from collections import deque, namedtuple
+from collections import deque
 from datetime import timedelta
 import functools
 import logging
@@ -1314,32 +1314,6 @@ class to_kafka(Stream):
 
     def flush(self, timeout=-1):
         self.producer.flush(timeout)
-
-
-@Stream.register_api()
-class to_kafka_batched(Stream):
-    def __init__(self, upstream, topic, producer_config, n, **kwargs):
-        import confluent_kafka as ck
-
-        self.topic = topic
-        self.producer = ck.Producer(producer_config)
-        self.n = n
-        self.buffer = []
-
-        Stream.__init__(self, upstream, ensure_io_loop=True, **kwargs)
-
-    def update(self, x, who=None):
-        self.buffer.append(x)
-        if len(self.buffer) >= self.n:
-            self.loop.add_callback(self.flush, False)
-
-    @gen.coroutine
-    def flush(self, producer=True):
-        for x in self.buffer:
-            yield self.producer.produce(self.topic, x)
-        self.buffer = []
-        if producer:
-            yield self.producer.flush()
 
 
 def sync(loop, func, *args, **kwargs):

--- a/streamz/core.py
+++ b/streamz/core.py
@@ -1274,13 +1274,10 @@ class to_kafka(Stream):
 
     @gen.coroutine
     def poll(self):
-        while True:
+        while not self.stopped:
             # executes callbacks for any delivered data, in this thread
-            # if no meesages were sent, nothing happens
+            # if no messages were sent, nothing happens
             self.producer.poll(0)
-            if self.stopped:
-                # kill producer?
-                break
             yield gen.sleep(self.polltime)
 
     def update(self, x, who=None):

--- a/streamz/core.py
+++ b/streamz/core.py
@@ -17,10 +17,6 @@ from tornado.locks import Condition
 from tornado.ioloop import IOLoop
 from tornado.queues import Queue
 try:
-    import confluent_kafka as ck
-except ImportError:
-    ck = None  # confluent_kafka is only required when interacting with Kafka
-try:
     from tornado.ioloop import PollIOLoop
 except ImportError:
     PollIOLoop = None  # dropped in tornado 6.0
@@ -1268,6 +1264,8 @@ class to_kafka(Stream):
     test 0
     """
     def __init__(self, upstream, topic, producer_config, **kwargs):
+        import confluent_kafka as ck
+
         self.topic = topic
         self.producer = ck.Producer(producer_config)
         atexit.register(self.producer.flush)

--- a/streamz/sources.py
+++ b/streamz/sources.py
@@ -1,6 +1,5 @@
 from glob import glob
 import os
-import weakref
 
 import time
 import tornado.ioloop

--- a/streamz/sources.py
+++ b/streamz/sources.py
@@ -209,7 +209,6 @@ class from_kafka(Source):
 
     def start(self):
         import confluent_kafka as ck
-        import weakref
         if self.stopped:
             self.stopped = False
             self.consumer = ck.Consumer(self.cpars)
@@ -219,14 +218,9 @@ class from_kafka(Source):
             # blocks for consumer thread to come up
             self.consumer.get_watermark_offsets(tp)
             self.loop.add_callback(self.poll_kafka)
-            self._destruct = weakref.finalize(self, from_kafka._close_consumer,
-                                              weakref.ref(self))
 
     def _close_consumer(self):
-        import weakref
-        if isinstance(self, weakref.ref):
-            self = self()
-        if self is not None and self.consumer is not None:
+        if self.consumer is not None:
             consumer = self.consumer
             self.consumer = None
             consumer.unsubscribe()

--- a/streamz/sources.py
+++ b/streamz/sources.py
@@ -193,7 +193,7 @@ class from_kafka(Source):
     def do_poll(self):
         if self.consumer is not None:
             msg = self.consumer.poll(0)
-            if msg and msg.value():
+            if msg and msg.value() and msg.error() is None:
                 return msg.value()
 
     @gen.coroutine
@@ -206,26 +206,19 @@ class from_kafka(Source):
                 yield gen.sleep(self.poll_interval)
             if self.stopped:
                 break
+        self._close_consumer()
 
     def start(self):
         import confluent_kafka as ck
-        import distributed
         if self.stopped:
-            finalize = distributed.compatibility.finalize
             self.stopped = False
-            self.loop.add_callback(self.poll_kafka)
             self.consumer = ck.Consumer(self.cpars)
             self.consumer.subscribe(self.topics)
+            tp = ck.TopicPartition(self.topics[0], 0, 0)
 
-            def close(ref):
-                ob = ref()
-                if ob is not None and ob.consumer is not None:
-                    consumer = ob.consumer
-                    ob.consumer = None
-                    consumer.unsubscribe()
-                    consumer.close()  # may raise with latest ck, that's OK
-
-            finalize(self, close, weakref.ref(self))
+            # blocks for consumer thread to come up
+            self.consumer.get_watermark_offsets(tp)
+            self.loop.add_callback(self.poll_kafka)
 
     def _close_consumer(self):
         if self.consumer is not None:
@@ -252,24 +245,23 @@ class FromKafkaBatched(Stream):
     @gen.coroutine
     def poll_kafka(self):
         import confluent_kafka as ck
-        consumer = ck.Consumer(self.consumer_params)
 
         try:
             while not self.stopped:
                 out = []
-
                 for partition in range(self.npartitions):
                     tp = ck.TopicPartition(self.topic, partition, 0)
                     try:
-                        low, high = consumer.get_watermark_offsets(tp,
-                                                                   timeout=0.1)
+                        low, high = self.consumer.get_watermark_offsets(
+                            tp, timeout=0.1)
                     except (RuntimeError, ck.KafkaException):
                         continue
                     current_position = self.positions[partition]
                     lowest = max(current_position, low)
-                    out.append((self.consumer_params, self.topic, partition,
-                                lowest, high - 1))
-                    self.positions[partition] = high
+                    if high > lowest:
+                        out.append((self.consumer_params, self.topic, partition,
+                                    lowest, high - 1))
+                        self.positions[partition] = high
 
                 for part in out:
                     yield self._emit(part)
@@ -277,11 +269,19 @@ class FromKafkaBatched(Stream):
                 else:
                     yield gen.sleep(self.poll_interval)
         finally:
-            consumer.close()
+            self.consumer.unsubscribe()
+            self.consumer.close()
 
     def start(self):
-        self.stopped = False
-        self.loop.add_callback(self.poll_kafka)
+        import confluent_kafka as ck
+        if self.stopped:
+            self.consumer = ck.Consumer(self.consumer_params)
+            self.stopped = False
+            tp = ck.TopicPartition(self.topic, 0, 0)
+
+            # blocks for consumer thread to come up
+            self.consumer.get_watermark_offsets(tp)
+            self.loop.add_callback(self.poll_kafka)
 
 
 @Stream.register_api(staticmethod)
@@ -351,7 +351,7 @@ def get_message_batch(kafka_params, topic, partition, low, high, timeout=None):
     try:
         while True:
             msg = consumer.poll(0)
-            if msg and msg.value():
+            if msg and msg.value() and msg.error() is None:
                 if high >= msg.offset():
                     out.append(msg.value())
                 if high <= msg.offset():

--- a/streamz/tests/test_core.py
+++ b/streamz/tests/test_core.py
@@ -942,7 +942,7 @@ def dont_test_stream_kwargs(clean):
 
 
 @pytest.fixture
-def thread(loop):
+def thread(loop):   # noqa: E811
     from threading import Thread, Event
     thread = Thread(target=loop.start)
     thread.daemon = True

--- a/streamz/tests/test_core.py
+++ b/streamz/tests/test_core.py
@@ -943,7 +943,7 @@ def dont_test_stream_kwargs(clean):  # noqa: F811
 
 
 @pytest.fixture
-def thread(loop):  # noqa: E811
+def thread(loop):  # noqa: F811
     from threading import Thread, Event
     thread = Thread(target=loop.start)
     thread.daemon = True

--- a/streamz/tests/test_dask.py
+++ b/streamz/tests/test_dask.py
@@ -73,7 +73,7 @@ def test_zip(c, s, a, b):
     assert L == [(1, 'a'), (2, 'b')]
 
 
-@pytest.mark.slow  
+@pytest.mark.slow
 def test_sync(loop):  # noqa: F811
     with cluster() as (s, [a, b]):
         with Client(s['address'], loop=loop) as client:  # noqa: F841
@@ -91,7 +91,7 @@ def test_sync(loop):  # noqa: F811
 
 
 @pytest.mark.slow
-def test_sync_2(loop):  # noqa: E811
+def test_sync_2(loop):  # noqa: F811
     with cluster() as (s, [a, b]):
         with Client(s['address'], loop=loop):  # noqa: F841
             source = Stream()
@@ -132,7 +132,7 @@ def test_buffer(c, s, a, b):
 
 
 @pytest.mark.slow
-def test_buffer_sync(loop):  # noqa: E811
+def test_buffer_sync(loop):  # noqa: F811
     with cluster() as (s, [a, b]):
         with Client(s['address'], loop=loop) as c:  # noqa: F841
             source = Stream()
@@ -155,9 +155,9 @@ def test_buffer_sync(loop):  # noqa: E811
             assert L == list(map(inc, range(10)))
 
 
-@pytest.mark.xfail(reason='')  # noqa: F811
+@pytest.mark.xfail(reason='')
 @pytest.mark.slow
-def test_stream_shares_client_loop(loop):  # noqa: E811
+def test_stream_shares_client_loop(loop):  # noqa: F811
     with cluster() as (s, [a, b]):
         with Client(s['address'], loop=loop) as client:  # noqa: F841
             source = Stream()

--- a/streamz/tests/test_dask.py
+++ b/streamz/tests/test_dask.py
@@ -74,7 +74,7 @@ def test_zip(c, s, a, b):
 
 
 @pytest.mark.slow
-def test_sync(loop):
+def test_sync(loop):  # noqa: E811
     with cluster() as (s, [a, b]):
         with Client(s['address'], loop=loop) as client:  # flake8: noqa
             source = Stream()
@@ -91,7 +91,7 @@ def test_sync(loop):
 
 
 @pytest.mark.slow
-def test_sync_2(loop):
+def test_sync_2(loop):  # noqa: E811
     with cluster() as (s, [a, b]):
         with Client(s['address'], loop=loop):  # flake8: noqa
             source = Stream()
@@ -132,7 +132,7 @@ def test_buffer(c, s, a, b):
 
 
 @pytest.mark.slow
-def test_buffer_sync(loop):
+def test_buffer_sync(loop):  # noqa: E811
     with cluster() as (s, [a, b]):
         with Client(s['address'], loop=loop) as c:  # flake8: noqa
             source = Stream()
@@ -158,7 +158,7 @@ def test_buffer_sync(loop):
 
 @pytest.mark.xfail(reason='')
 @pytest.mark.slow
-def test_stream_shares_client_loop(loop):
+def test_stream_shares_client_loop(loop):  # noqa: E811
     with cluster() as (s, [a, b]):
         with Client(s['address'], loop=loop) as client:  # flake8: noqa
             source = Stream()

--- a/streamz/tests/test_kafka.py
+++ b/streamz/tests/test_kafka.py
@@ -150,8 +150,7 @@ def test_to_kafka():
         source.emit('final message')
         kafka.flush()
         wait_for(lambda: len(out) == 11, 10, period=0.1)
-        assert out[-1].msg == b'final message'
-        assert out[-1].err is None
+        assert out[-1] == b'final message'
 
 
 @gen_test(timeout=60)

--- a/streamz/tests/test_kafka.py
+++ b/streamz/tests/test_kafka.py
@@ -202,6 +202,7 @@ def test_kafka_batch():
 
 @gen_cluster(client=True, timeout=60)
 def test_kafka_dask_batch(c, s, w1, w2):
+    import time
     j = random.randint(0, 10000)
     ARGS = {'bootstrap.servers': 'localhost:9092',
             'group.id': 'streamz-test%i' % j}

--- a/streamz/tests/test_kafka.py
+++ b/streamz/tests/test_kafka.py
@@ -145,7 +145,7 @@ def test_from_kafka():
 
 
 @gen_test(timeout=60)
-async def test_to_kafka():
+def test_to_kafka():
     ARGS = {'bootstrap.servers': 'localhost:9092'}
     with kafka_service():
         source = Stream()

--- a/streamz/tests/test_kafka.py
+++ b/streamz/tests/test_kafka.py
@@ -122,6 +122,7 @@ def test_from_kafka():
         stream = Stream.from_kafka([TOPIC], ARGS, asynchronous=True)
         out = stream.sink_to_list()
         stream.start()
+        sleep(5)
         for i in range(10):
             kafka.produce(TOPIC, b'value-%d' % i)
         kafka.flush()
@@ -173,6 +174,7 @@ def test_from_kafka_thread():
         stream = Stream.from_kafka([TOPIC], ARGS)
         out = stream.sink_to_list()
         stream.start()
+        sleep(2)
         for i in range(10):
             kafka.produce(TOPIC, b'value-%d' % i)
         kafka.flush()
@@ -202,6 +204,7 @@ def test_kafka_batch():
         stream = Stream.from_kafka_batched(TOPIC, ARGS)
         out = stream.sink_to_list()
         stream.start()
+        sleep(2)
         for i in range(10):
             kafka.produce(TOPIC, b'value-%d' % i)
         kafka.flush()
@@ -219,6 +222,7 @@ def test_kafka_dask_batch(c, s, w1, w2):
         stream = Stream.from_kafka_batched(TOPIC, ARGS, asynchronous=True,
                                            dask=True)
         stream.start()
+        sleep(2)
         assert isinstance(stream, DaskStream)
         out = stream.gather().sink_to_list()
         for i in range(10):

--- a/streamz/tests/test_kafka.py
+++ b/streamz/tests/test_kafka.py
@@ -167,12 +167,12 @@ def test_from_kafka_thread():
             kafka.produce(TOPIC, b'value-%d' % i)
         kafka.flush()
         # it takes some time for messages to come back out of kafka
-        wait_for(lambda: len(out) == 10, 10, period=0.1)
+        yield await_for(lambda: len(out) == 10, 10, period=0.1)
 
         assert out[-1] == b'value-9'
         kafka.produce(TOPIC, b'final message')
         kafka.flush()
-        wait_for(lambda: out[-1] == b'final message', 10, period=0.1)
+        yield await_for(lambda: out[-1] == b'final message', 10, period=0.1)
 
         stream._close_consumer()
         kafka.produce(TOPIC, b'lost message')

--- a/streamz/tests/test_kafka.py
+++ b/streamz/tests/test_kafka.py
@@ -186,7 +186,7 @@ def test_kafka_batch():
         kafka.flush()
         # out may still be empty or first item of out may be []
         wait_for(lambda: any(out) and out[-1][-1] == b'value-9', 10, period=0.2)
-        stream.stopped = True
+        stream.upstream.stopped = True
 
 
 @gen_cluster(client=True, timeout=60)
@@ -209,4 +209,4 @@ def test_kafka_dask_batch(c, s, w1, w2):
             timeout -= 0.2
             assert timeout > 0, "Timeout"
         assert out[0][-1] == b'value-9'
-        stream.stopped = True
+        stream.upstream.stopped = True

--- a/streamz/tests/test_kafka.py
+++ b/streamz/tests/test_kafka.py
@@ -153,8 +153,7 @@ def test_to_kafka():
         out = kafka.sink_to_list()
 
         for i in range(10):
-            await source.emit(b'value-%d' % i, asynchronous=True)
-        print(out)
+            yield source.emit(b'value-%d' % i, asynchronous=True)
 
         source.emit('final message')
         kafka.flush()

--- a/streamz/tests/test_kafka.py
+++ b/streamz/tests/test_kafka.py
@@ -202,7 +202,6 @@ def test_kafka_batch():
 
 @gen_cluster(client=True, timeout=60)
 def test_kafka_dask_batch(c, s, w1, w2):
-    import time
     j = random.randint(0, 10000)
     ARGS = {'bootstrap.servers': 'localhost:9092',
             'group.id': 'streamz-test%i' % j}


### PR DESCRIPTION
Attempts to extend #216 following feedback 

Still contains a gen-sleep in the dask test. This could be thought OK usage, since that's not the way that people will use it in the wild. Good chances of these tests failing now again on Travis, we'll see.